### PR TITLE
fix: Change in error return for debugging and copilot review

### DIFF
--- a/scc/provider/datasource_subaccount_k8s_service_channel.go
+++ b/scc/provider/datasource_subaccount_k8s_service_channel.go
@@ -148,9 +148,9 @@ func (d *SubaccountK8SServiceChannelDataSource) Read(ctx context.Context, req da
 		return
 	}
 
-	responseModel, err := SubaccountK8SServiceChannelValueFrom(ctx, data, respObj)
-	if err != nil {
-		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", err))
+	responseModel, diags := SubaccountK8SServiceChannelValueFrom(ctx, data, respObj)
+	if diags.HasError() {
+		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", diags))
 		return
 	}
 

--- a/scc/provider/datasource_subaccount_k8s_service_channels.go
+++ b/scc/provider/datasource_subaccount_k8s_service_channels.go
@@ -154,9 +154,9 @@ func (d *SubaccountK8SServiceChannelsDataSource) Read(ctx context.Context, req d
 		return
 	}
 
-	responseModel, err := SubaccountK8SServiceChannelsValueFrom(ctx, data, respObj)
-	if err != nil {
-		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelsFailed, fmt.Sprintf("%s", err))
+	responseModel, diags := SubaccountK8SServiceChannelsValueFrom(ctx, data, respObj)
+	if diags.HasError() {
+		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelsFailed, fmt.Sprintf("%s", diags))
 		return
 	}
 

--- a/scc/provider/resource_subaccount_k8s_service_channel.go
+++ b/scc/provider/resource_subaccount_k8s_service_channel.go
@@ -178,9 +178,9 @@ func (r *SubaccountK8SServiceChannelResource) Create(ctx context.Context, req re
 		}
 	}
 
-	responseModel, err := SubaccountK8SServiceChannelValueFrom(ctx, plan, *serviceChannelRespObj)
-	if err != nil {
-		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", err))
+	responseModel, diags := SubaccountK8SServiceChannelValueFrom(ctx, plan, *serviceChannelRespObj)
+	if diags.HasError() {
+		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", diags))
 		return
 	}
 
@@ -211,9 +211,9 @@ func (r *SubaccountK8SServiceChannelResource) Read(ctx context.Context, req reso
 		return
 	}
 
-	responseModel, err := SubaccountK8SServiceChannelValueFrom(ctx, state, respObj)
-	if err != nil {
-		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", err))
+	responseModel, diags := SubaccountK8SServiceChannelValueFrom(ctx, state, respObj)
+	if diags.HasError() {
+		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", diags))
 		return
 	}
 
@@ -266,9 +266,9 @@ func (r *SubaccountK8SServiceChannelResource) Update(ctx context.Context, req re
 		return
 	}
 
-	responseModel, err := SubaccountK8SServiceChannelValueFrom(ctx, plan, respObj)
-	if err != nil {
-		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", err))
+	responseModel, diags := SubaccountK8SServiceChannelValueFrom(ctx, plan, respObj)
+	if diags.HasError() {
+		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", diags))
 		return
 	}
 
@@ -300,9 +300,9 @@ func (r *SubaccountK8SServiceChannelResource) Delete(ctx context.Context, req re
 		return
 	}
 
-	responseModel, err := SubaccountK8SServiceChannelValueFrom(ctx, state, respObj)
-	if err != nil {
-		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", err))
+	responseModel, diags := SubaccountK8SServiceChannelValueFrom(ctx, state, respObj)
+	if diags.HasError() {
+		resp.Diagnostics.AddError(errMsgMapSubaccountK8SServiceChannelFailed, fmt.Sprintf("%s", diags))
 		return
 	}
 

--- a/scc/provider/type_subaccount_k8s_service_channel.go
+++ b/scc/provider/type_subaccount_k8s_service_channel.go
@@ -5,6 +5,7 @@ import (
 
 	apiobjects "github.com/SAP/terraform-provider-scc/internal/api/apiObjects"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -52,14 +53,17 @@ type SubaccountK8SServiceChannelsConfig struct {
 	SubaccountK8SServiceChannels []SubaccountK8SServiceChannel `tfsdk:"subaccount_k8s_service_channels"`
 }
 
-func SubaccountK8SServiceChannelValueFrom(ctx context.Context, plan SubaccountK8SServiceChannelConfig, value apiobjects.SubaccountK8SServiceChannel) (SubaccountK8SServiceChannelConfig, error) {
+func SubaccountK8SServiceChannelValueFrom(ctx context.Context, plan SubaccountK8SServiceChannelConfig, value apiobjects.SubaccountK8SServiceChannel) (SubaccountK8SServiceChannelConfig, diag.Diagnostics) {
 	stateObj := SubaccountK8SServiceChannelStateData{
 		Connected:               types.BoolValue(value.State.Connected),
 		OpenedConnections:       types.Int64Value(value.State.OpenedConnections),
 		ConnectedSinceTimeStamp: types.Int64Value(value.State.ConnectedSinceTimeStamp),
 	}
 
-	state, _ := types.ObjectValueFrom(ctx, SubaccountK8SServiceChannelStateType, stateObj)
+	state, err := types.ObjectValueFrom(ctx, SubaccountK8SServiceChannelStateType, stateObj)
+	if err.HasError() {
+		return SubaccountK8SServiceChannelConfig{}, err
+	}
 
 	model := &SubaccountK8SServiceChannelConfig{
 		RegionHost:  plan.RegionHost,
@@ -78,7 +82,7 @@ func SubaccountK8SServiceChannelValueFrom(ctx context.Context, plan SubaccountK8
 	return *model, nil
 }
 
-func SubaccountK8SServiceChannelsValueFrom(ctx context.Context, plan SubaccountK8SServiceChannelsConfig, value apiobjects.SubaccountK8SServiceChannels) (SubaccountK8SServiceChannelsConfig, error) {
+func SubaccountK8SServiceChannelsValueFrom(ctx context.Context, plan SubaccountK8SServiceChannelsConfig, value apiobjects.SubaccountK8SServiceChannels) (SubaccountK8SServiceChannelsConfig, diag.Diagnostics) {
 	serviceChannels := []SubaccountK8SServiceChannel{}
 	for _, channel := range value.SubaccountK8SServiceChannels {
 		stateObj := SubaccountK8SServiceChannelStateData{
@@ -87,7 +91,10 @@ func SubaccountK8SServiceChannelsValueFrom(ctx context.Context, plan SubaccountK
 			ConnectedSinceTimeStamp: types.Int64Value(channel.State.ConnectedSinceTimeStamp),
 		}
 
-		state, _ := types.ObjectValueFrom(ctx, SubaccountK8SServiceChannelStateType, stateObj)
+		state, err := types.ObjectValueFrom(ctx, SubaccountK8SServiceChannelStateType, stateObj)
+		if err.HasError() {
+			return SubaccountK8SServiceChannelsConfig{}, err
+		}
 
 		c := SubaccountK8SServiceChannel{
 			K8SCluster:  types.StringValue(channel.K8SCluster),


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Returning ctx.Err() masks the real error from types.ObjectValueFrom; return the original err instead of ctx.Err(). This was the suggestion from copilot on PR: https://github.com/SAP/terraform-provider-scc/pull/93

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
