### PR TITLE
fix: Change in validators for system mapping internal/virtual port

### DIFF
--- a/docs/data-sources/system_mapping.md
+++ b/docs/data-sources/system_mapping.md
@@ -57,10 +57,10 @@ __UI Note:__ This attribute appears under different names depending on the proto
 * **RFC** → "Virtual Instance Number/ Virtual System ID"
 
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing
 
 ### Read-Only
 
@@ -105,10 +105,10 @@ __UI Note:__ This field may appear under different names in the Cloud Connector 
 				
 				
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing
 - `protocol` (String) Protocol used when sending requests and receiving responses, which must be one of the following values:
   | protocol | description | 
   | --- | --- | 

--- a/docs/data-sources/system_mappings.md
+++ b/docs/data-sources/system_mappings.md
@@ -65,10 +65,10 @@ __UI Note:__ This attribute appears under different names depending on the proto
 * **RFC** → "Virtual Instance Number/ Virtual System ID"
 
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing
 
 Read-Only:
 
@@ -113,10 +113,10 @@ __UI Note:__ This field may appear under different names in the Cloud Connector 
 				
 				
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing
 - `protocol` (String) Protocol used when sending requests and receiving responses, which must be one of the following values:
   | protocol | description | 
   | --- | --- | 

--- a/docs/resources/system_mapping.md
+++ b/docs/resources/system_mapping.md
@@ -67,10 +67,10 @@ __UI Note:__ This field may appear under different names in the Cloud Connector 
 				
 				
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing
 - `protocol` (String) Protocol used when sending requests and receiving responses, which must be one of the following values:
   | protocol | description | 
   | --- | --- | 
@@ -99,10 +99,10 @@ __UI Note:__ This attribute appears under different names depending on the proto
 * **RFC** → "Virtual Instance Number/ Virtual System ID"
 
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing
 
 ### Optional
 

--- a/scc/provider/datasource_system_mapping.go
+++ b/scc/provider/datasource_system_mapping.go
@@ -68,8 +68,8 @@ Note: In the UI, this attribute may appear with different names depending on the
 				Required: true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[A-Za-z0-9.-]+$`),
-						"must contain only letters, numbers, dots, and dashes (no underscores recommended)",
+						regexp.MustCompile(`^[a-z0-9.-]+$`),
+						"must contain only lowercase letters, numbers, dots, and dashes (no underscores recommended)",
 					),
 				},
 			},
@@ -82,16 +82,13 @@ __UI Note:__ This attribute appears under different names depending on the proto
 * **RFC** → "Virtual Instance Number/ Virtual System ID"
 
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port`,
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing`,
 				Required: true,
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^([0-9]{1,5}|sapgw[0-9]{2}|sapgw[0-9]{2}s|33[0-9]{2}|48[0-9]{2})$`),
-						"must be numeric (0–65535), sapgwXX, sapgwXXs, 33XX, or 48XX",
-					),
+					systemMapping.ValidatePort(),
 				},
 			},
 			"internal_host": schema.StringAttribute{
@@ -103,8 +100,8 @@ Note: In the UI, this attribute may appear with different names depending on the
 				Computed: true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[A-Za-z0-9.-]+$`),
-						"must contain only letters, numbers, dots, and dashes (no underscores recommended)",
+						regexp.MustCompile(`^[a-z0-9.-]+$`),
+						"must contain only lowercase letters, numbers, dots, and dashes (no underscores recommended)",
 					),
 				},
 			},
@@ -116,16 +113,14 @@ __UI Note:__ This field may appear under different names in the Cloud Connector 
 				
 				
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port`,
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing`,
+
 				Computed: true,
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^([0-9]{1,5}|sapgw[0-9]{2}|sapgw[0-9]{2}s|33[0-9]{2}|48[0-9]{2})$`),
-						"must be numeric (0–65535), sapgwXX, sapgwXXs, 33XX, or 48XX",
-					),
+					systemMapping.ValidatePort(),
 				},
 			},
 			"creation_date": schema.StringAttribute{

--- a/scc/provider/datasource_system_mappings.go
+++ b/scc/provider/datasource_system_mappings.go
@@ -73,8 +73,8 @@ Note: In the UI, this attribute may appear with different names depending on the
 							Required: true,
 							Validators: []validator.String{
 								stringvalidator.RegexMatches(
-									regexp.MustCompile(`^[A-Za-z0-9.-]+$`),
-									"must contain only letters, numbers, dots, and dashes (no underscores recommended)",
+									regexp.MustCompile(`^[a-z0-9.-]+$`),
+									"must contain only lowercase letters, numbers, dots, and dashes (no underscores recommended)",
 								),
 							},
 						},
@@ -87,16 +87,13 @@ __UI Note:__ This attribute appears under different names depending on the proto
 * **RFC** → "Virtual Instance Number/ Virtual System ID"
 
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port`,
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing`,
 							Required: true,
 							Validators: []validator.String{
-								stringvalidator.RegexMatches(
-									regexp.MustCompile(`^([0-9]{1,5}|sapgw[0-9]{2}|sapgw[0-9]{2}s|33[0-9]{2}|48[0-9]{2})$`),
-									"must be numeric (0–65535), sapgwXX, sapgwXXs, 33XX, or 48XX",
-								),
+								systemMapping.ValidatePort(),
 							},
 						},
 						"internal_host": schema.StringAttribute{
@@ -108,8 +105,8 @@ Note: In the UI, this attribute may appear with different names depending on the
 							Computed: true,
 							Validators: []validator.String{
 								stringvalidator.RegexMatches(
-									regexp.MustCompile(`^[A-Za-z0-9.-]+$`),
-									"must contain only letters, numbers, dots, and dashes (no underscores recommended)",
+									regexp.MustCompile(`^[a-z0-9.-]+$`),
+									"must contain only lowercase letters, numbers, dots, and dashes (no underscores recommended)",
 								),
 							},
 						},
@@ -121,16 +118,14 @@ __UI Note:__ This field may appear under different names in the Cloud Connector 
 				
 				
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port`,
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing`,
+
 							Computed: true,
 							Validators: []validator.String{
-								stringvalidator.RegexMatches(
-									regexp.MustCompile(`^([0-9]{1,5}|sapgw[0-9]{2}|sapgw[0-9]{2}s|33[0-9]{2}|48[0-9]{2})$`),
-									"must be numeric (0–65535), sapgwXX, sapgwXXs, 33XX, or 48XX",
-								),
+								systemMapping.ValidatePort(),
 							},
 						},
 						"creation_date": schema.StringAttribute{

--- a/scc/provider/resource_system_mapping.go
+++ b/scc/provider/resource_system_mapping.go
@@ -79,8 +79,8 @@ Note: In the UI, this attribute may appear with different names depending on the
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[A-Za-z0-9.-]+$`),
-						"must contain only letters, numbers, dots, and dashes (no underscores recommended)",
+						regexp.MustCompile(`^[a-z0-9.-]+$`),
+						"must contain only lowercase letters, numbers, dots, and dashes (no underscores recommended)",
 					),
 				},
 			},
@@ -93,20 +93,17 @@ __UI Note:__ This attribute appears under different names depending on the proto
 * **RFC** → "Virtual Instance Number/ Virtual System ID"
 
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port`,
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing`,
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^([0-9]{1,5}|sapgw[0-9]{2}|sapgw[0-9]{2}s|33[0-9]{2}|48[0-9]{2})$`),
-						"must be numeric (0–65535), sapgwXX, sapgwXXs, 33XX, or 48XX",
-					),
+					systemMapping.ValidatePort(),
 				},
 			},
 			"internal_host": schema.StringAttribute{
@@ -118,8 +115,8 @@ Note: In the UI, this attribute may appear with different names depending on the
 				Required: true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[A-Za-z0-9.-]+$`),
-						"must contain only letters, numbers, dots, and dashes (no underscores recommended)",
+						regexp.MustCompile(`^[a-z0-9.-]+$`),
+						"must contain only lowercase letters, numbers, dots, and dashes (no underscores recommended)",
 					),
 				},
 			},
@@ -131,16 +128,14 @@ __UI Note:__ This field may appear under different names in the Cloud Connector 
 				
 				
 __Allowed formats:__
-* **Numeric (0–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
-* **sapgwXX** or **sapgwXXs** → for RFC without load balancing
-* **33XX** → Classic RFC Port
-* **48XX** → Secure RFC Port`,
+* **Numeric (1–65535)** → for HTTP(S), TCP/TCPS, LDAP/LDAPS
+* **sapmsSID** → for RFC with load balancing
+* **sapgwXX** → for RFC without load balancing
+* **sapgwXXs** → for Secure RFC without load balancing`,
+
 				Required: true,
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^([0-9]{1,5}|sapgw[0-9]{2}|sapgw[0-9]{2}s|33[0-9]{2}|48[0-9]{2})$`),
-						"must be numeric (0–65535), sapgwXX, sapgwXXs, 33XX, or 48XX",
-					),
+					systemMapping.ValidatePort(),
 				},
 			},
 			"creation_date": schema.StringAttribute{

--- a/validation/systemMapping/port_validator.go
+++ b/validation/systemMapping/port_validator.go
@@ -1,0 +1,104 @@
+package systemMapping
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// --- Wrapper ---
+type PortValidator struct{}
+
+func (v PortValidator) Description(_ context.Context) string {
+	return "Validates internal_port/virtual_port based on protocol"
+}
+
+func (v PortValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v PortValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	var protocol types.String
+	diags := req.Config.GetAttribute(ctx, path.Root("protocol"), &protocol)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	portValue := req.ConfigValue.ValueString()
+	protocolValue := protocol.ValueString()
+
+	switch protocolValue {
+	case "HTTP", "HTTPS", "TCP", "TCPS", "LDAP", "LDAPS":
+		// Only numeric 1–65535
+		if !isNumericInRange(portValue, 1, 65535) {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid Port",
+				fmt.Sprintf("Value %q is not valid for protocol %q. Must be numeric between 1 and 65535.", portValue, protocolValue),
+			)
+		}
+
+	case "RFC":
+		// With LB: port 1–65535 OR sapmsSID
+		// Without LB: sapgwXX OR port 100–65535
+		if !ValidateRFCValue(portValue) {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid RFC Value",
+				fmt.Sprintf("Value %q is not valid for RFC. Allowed: numeric 1–65535, sapmsSID, or sapgwXX (or numeric 100–65535 without LB).", portValue),
+			)
+		}
+
+	case "RFCS":
+		// With LB: port 1–65535 OR sapmsSID
+		// Without LB: sapgwXXs OR port 100–65535
+		if !ValidateRFCSValue(portValue) {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid RFCS Value",
+				fmt.Sprintf("Value %q is not valid for RFCS. Allowed: numeric 1–65535, sapmsSID, or sapgwXXs (or numeric 100–65535 without LB).", portValue),
+			)
+		}
+	}
+}
+
+func isNumericInRange(s string, min, max int) bool {
+	if !regexp.MustCompile(`^[0-9]{1,5}$`).MatchString(s) {
+		return false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return false
+	}
+	return n >= min && n <= max
+}
+
+func ValidateHTTPPort(value string) bool {
+	return isNumericInRange(value, 1, 65535)
+}
+
+func ValidateRFCValue(value string) bool {
+	return isNumericInRange(value, 1, 65535) ||
+		regexp.MustCompile(`^sapms[A-Z0-9]{3}$`).MatchString(value) ||
+		regexp.MustCompile(`^sapgw[0-9]{2}$`).MatchString(value)
+}
+
+func ValidateRFCSValue(value string) bool {
+	return isNumericInRange(value, 1, 65535) ||
+		regexp.MustCompile(`^sapms[A-Z0-9]{3}$`).MatchString(value) ||
+		regexp.MustCompile(`^sapgw[0-9]{2}s$`).MatchString(value)
+}
+
+func ValidatePort() validator.String {
+	return PortValidator{}
+}

--- a/validation/systemMapping/port_validator.go
+++ b/validation/systemMapping/port_validator.go
@@ -11,6 +11,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+var reservedSIDs = map[string]struct{}{
+	"ADD": {}, "ALL": {}, "AND": {}, "ANY": {}, "ASC": {}, "AUX": {}, "COM": {}, "CON": {}, "DBA": {}, "END": {},
+	"EPS": {}, "FOR": {}, "GID": {}, "IBM": {}, "INT": {}, "KEY": {}, "LOG": {}, "LPT": {}, "MON": {}, "NIX": {},
+	"NOT": {}, "NUL": {}, "OFF": {}, "OMS": {}, "PRN": {}, "RAW": {}, "ROW": {}, "SAP": {}, "SET": {}, "SGA": {},
+	"SHG": {}, "SID": {}, "SQL": {}, "SYS": {}, "TMP": {}, "TOP": {}, "UID": {}, "USE": {}, "USR": {}, "VAR": {},
+}
+
 // --- Wrapper ---
 type PortValidator struct{}
 
@@ -55,7 +62,8 @@ func (v PortValidator) ValidateString(ctx context.Context, req validator.StringR
 			resp.Diagnostics.AddAttributeError(
 				req.Path,
 				"Invalid RFC Value",
-				fmt.Sprintf("Value %q is not valid for RFC. Allowed: numeric 1–65535, sapmsSID, or sapgwXX (or numeric 100–65535 without LB).", portValue),
+				fmt.Sprintf("Value %q is not valid for RFC. Allowed: numeric 1–65535, sapmsSID (valid 3-char SID), or sapgwXX (00–99) (or numeric 100–65535 without LB)."+
+					"Ensure the SID is not one of the reserved SIDs (e.g., SAP, SYS, ALL, COM, etc.).", portValue),
 			)
 		}
 
@@ -66,7 +74,8 @@ func (v PortValidator) ValidateString(ctx context.Context, req validator.StringR
 			resp.Diagnostics.AddAttributeError(
 				req.Path,
 				"Invalid RFCS Value",
-				fmt.Sprintf("Value %q is not valid for RFCS. Allowed: numeric 1–65535, sapmsSID, or sapgwXXs (or numeric 100–65535 without LB).", portValue),
+				fmt.Sprintf("Value %q is not valid for RFCS. Allowed: numeric 1–65535, sapmsSID (valid 3-char SID), or sapgwXXs (00–99) (or numeric 100–65535 without LB)."+
+					"Ensure the SID is not one of the reserved SIDs (e.g., SAP, SYS, ALL, COM, etc.).", portValue),
 			)
 		}
 	}
@@ -83,20 +92,49 @@ func isNumericInRange(s string, min, max int) bool {
 	return n >= min && n <= max
 }
 
+func isValidSID(sid string) bool {
+	// Must be exactly 3 chars
+	if len(sid) != 3 {
+		return false
+	}
+	// Only uppercase alphanumeric
+	if !regexp.MustCompile(`^[A-Z0-9]+$`).MatchString(sid) {
+		return false
+	}
+	// First char must be a letter
+	if !regexp.MustCompile(`^[A-Z]`).MatchString(string(sid[0])) {
+		return false
+	}
+	// Reserved check
+	if _, reserved := reservedSIDs[sid]; reserved {
+		return false
+	}
+	return true
+}
+
+func isValidSapms(value string) bool {
+	re := regexp.MustCompile(`^sapms([A-Z0-9]{3})$`)
+	m := re.FindStringSubmatch(value)
+	if m == nil {
+		return false
+	}
+	return isValidSID(m[1])
+}
+
 func ValidateHTTPPort(value string) bool {
 	return isNumericInRange(value, 1, 65535)
 }
 
 func ValidateRFCValue(value string) bool {
 	return isNumericInRange(value, 1, 65535) ||
-		regexp.MustCompile(`^sapms[A-Z0-9]{3}$`).MatchString(value) ||
-		regexp.MustCompile(`^sapgw[0-9]{2}$`).MatchString(value)
+		regexp.MustCompile(`^sapgw[0-9]{2}$`).MatchString(value) ||
+		isValidSapms(value)
 }
 
 func ValidateRFCSValue(value string) bool {
 	return isNumericInRange(value, 1, 65535) ||
-		regexp.MustCompile(`^sapms[A-Z0-9]{3}$`).MatchString(value) ||
-		regexp.MustCompile(`^sapgw[0-9]{2}s$`).MatchString(value)
+		regexp.MustCompile(`^sapgw[0-9]{2}s$`).MatchString(value) ||
+		isValidSapms(value)
 }
 
 func ValidatePort() validator.String {

--- a/validation/systemMapping/port_validator_test.go
+++ b/validation/systemMapping/port_validator_test.go
@@ -1,0 +1,60 @@
+package systemMapping
+
+import "testing"
+
+func TestValidateHTTPPort(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{"80", true},
+		{"65535", true},
+		{"0", false},
+		{"70000", false},
+		{"abc", false},
+	}
+
+	for _, tt := range tests {
+		if got := ValidateHTTPPort(tt.value); got != tt.expected {
+			t.Errorf("HTTPPort(%q) expected %v, got %v", tt.value, tt.expected, got)
+		}
+	}
+}
+
+func TestValidateRFCValue(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{"sapmsABC", true},
+		{"sapgw00", true},
+		{"8080", true},
+		{"sapgw100", false},
+		{"invalid", false},
+	}
+
+	for _, tt := range tests {
+		if got := ValidateRFCValue(tt.value); got != tt.expected {
+			t.Errorf("RFCValue(%q) expected %v, got %v", tt.value, tt.expected, got)
+		}
+	}
+}
+
+func TestValidateRFCSValue(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{"sapmsXYZ", true},
+		{"sapgw01s", true},
+		{"443", true},
+		{"sapgw01", false}, // missing "s"
+		{"notvalid", false},
+	}
+
+	for _, tt := range tests {
+		if got := ValidateRFCSValue(tt.value); got != tt.expected {
+			t.Errorf("RFCSValue(%q) expected %v, got %v", tt.value, tt.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Closes: https://github.com/SAP/terraform-provider-scc/issues/139

- Hostnames: Provider now rejects uppercase or invalid hostnames early in validation.
- RFC/RFCS Ports: Clear distinction between load-balanced and non-load-balanced scenarios, preventing misconfigurations.
- Improved alignment with SAP Cloud Connector UI behavior and backend API expectations.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
