### PR TITLE
fix: Update resource_subaccount for import without using user credentials

### DIFF
--- a/scc/provider/resource_subaccount.go
+++ b/scc/provider/resource_subaccount.go
@@ -447,9 +447,7 @@ func appendAndCheckErrors(diags *diag.Diagnostics, newDiags diag.Diagnostics) bo
 func validateUpdateInputs(plan, state SubaccountConfig) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if plan.RegionHost.ValueString() != state.RegionHost.ValueString() ||
-		plan.Subaccount.ValueString() != state.Subaccount.ValueString() ||
-		plan.CloudUser.ValueString() != state.CloudUser.ValueString() ||
-		plan.CloudPassword.ValueString() != state.CloudPassword.ValueString() {
+		plan.Subaccount.ValueString() != state.Subaccount.ValueString() {
 		diags.AddError(
 			"Update Failed",
 			"failed to update the cloud connector subaccount due to mismatched configuration values",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Closes: https://github.com/SAP/terraform-provider-scc/issues/183

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
