### PR TITLE
feat: Add import identities support for subaccount and subaccount using auth resources

### DIFF
--- a/docs/resources/subaccount.md
+++ b/docs/resources/subaccount.md
@@ -130,4 +130,14 @@ Import is supported using the following syntax:
 # terraform import scc_subaccount.<resource_name> '<region_host>,<subaccount>`
 
 terraform import scc_subaccount.scc_sa 'cf.eu12.hana.ondemand.com,12345678-90ab-cdef-1234-567890abcdef'
+
+# this resource supports import using identity attribute from Terraform version 1.12 or higher
+
+import {
+  to = scc_subaccount.<resource_name>
+  identity = {
+    region_host = "<region_host>"
+    subaccount  = "<subaccount>"
+  }
+}
 ```

--- a/docs/resources/subaccount_using_auth.md
+++ b/docs/resources/subaccount_using_auth.md
@@ -131,4 +131,14 @@ Import is supported using the following syntax:
 # terraform import scc_subaccount_using_auth.<resource_name> '<region_host>,<subaccount>'
 
 terraform import scc_subaccount_using_auth.scc_sa_auth 'cf.eu12.hana.ondemand.com,12345678-90ab-cdef-1234-567890abcdef'
+
+# this resource supports import using identity attribute from Terraform version 1.12 or higher
+
+import {
+  to = scc_subaccount_using_auth.<resource_name>
+  identity = {
+    region_host = "<region_host>"
+    subaccount  = "<subaccount>"
+  }
+}
 ```

--- a/examples/resources/scc_subaccount/import.sh
+++ b/examples/resources/scc_subaccount/import.sh
@@ -1,3 +1,13 @@
 # terraform import scc_subaccount.<resource_name> '<region_host>,<subaccount>`
 
 terraform import scc_subaccount.scc_sa 'cf.eu12.hana.ondemand.com,12345678-90ab-cdef-1234-567890abcdef'
+
+# this resource supports import using identity attribute from Terraform version 1.12 or higher
+
+import {
+  to = scc_subaccount.<resource_name>
+  identity = {
+    region_host = "<region_host>"
+    subaccount  = "<subaccount>"
+  }
+}

--- a/examples/resources/scc_subaccount_using_auth/import.sh
+++ b/examples/resources/scc_subaccount_using_auth/import.sh
@@ -1,3 +1,13 @@
 # terraform import scc_subaccount_using_auth.<resource_name> '<region_host>,<subaccount>'
 
 terraform import scc_subaccount_using_auth.scc_sa_auth 'cf.eu12.hana.ondemand.com,12345678-90ab-cdef-1234-567890abcdef'
+
+# this resource supports import using identity attribute from Terraform version 1.12 or higher
+
+import {
+  to = scc_subaccount_using_auth.<resource_name>
+  identity = {
+    region_host = "<region_host>"
+    subaccount  = "<subaccount>"
+  }
+}

--- a/scc/provider/fixtures/resource_subaccount.yaml
+++ b/scc/provider/fixtures/resource_subaccount.yaml
@@ -40,7 +40,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:24:55 GMT
+                - Wed, 07 Jan 2026 13:12:46 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -50,10 +50,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8d0b3814-ce45-46d9-526e-77528ffdee46
+                - e9dc2685-c4cb-4793-76ec-001fcb237668
         status: 200 OK
         code: 200
-        duration: 984.120834ms
+        duration: 1.121759543s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -93,7 +93,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:24:55 GMT
+                - Wed, 07 Jan 2026 13:12:46 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -103,10 +103,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1dc4ae78-745c-4252-4811-39c8a921709a
+                - c446f234-c88b-4c50-77d7-c89aafda4bd8
         status: 200 OK
         code: 200
-        duration: 285.062333ms
+        duration: 457.422791ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -138,14 +138,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"subaccount added via terraform tests","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191101729,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727099000,"notBeforeTimeStamp":1758187499000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"subaccount added via terraform tests","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791571496,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327569000,"notBeforeTimeStamp":1767787969000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:01 GMT
+                - Wed, 07 Jan 2026 13:12:51 GMT
             Location:
                 - redacted
             Server:
@@ -159,10 +159,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 9431be1c-f251-4eb0-4fcc-9ad6c85d58cf
+                - f324f484-b835-405c-6b54-585bb88757cf
         status: 201 Created
         code: 201
-        duration: 5.897372878s
+        duration: 5.112116877s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -198,7 +198,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:02 GMT
+                - Wed, 07 Jan 2026 13:12:52 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -208,10 +208,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 26d1d10c-c250-4cda-7813-d18a2c09c007
+                - a9ad31ce-e756-42c5-4d3c-cd9053e844b9
         status: 204 No Content
         code: 204
-        duration: 696.672167ms
+        duration: 628.321042ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -251,7 +251,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:02 GMT
+                - Wed, 07 Jan 2026 13:12:52 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -261,10 +261,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 39190f55-9dce-4230-71d0-5d4e10c6cf43
+                - 20d2b2c3-36c8-4677-4bfd-95bdd0a09815
         status: 200 OK
         code: 200
-        duration: 283.944291ms
+        duration: 412.816584ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -304,7 +304,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:03 GMT
+                - Wed, 07 Jan 2026 13:12:53 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -314,10 +314,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7f3edfe4-788d-4731-41f2-f8345a198976
+                - bc5d70f4-8579-42b8-5151-465cf62fb9a4
         status: 200 OK
         code: 200
-        duration: 287.714001ms
+        duration: 308.876417ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -349,14 +349,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"subaccount added via terraform tests","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191101729,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727099000,"notBeforeTimeStamp":1758187499000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"subaccount added via terraform tests","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791571496,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327569000,"notBeforeTimeStamp":1767787969000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:03 GMT
+                - Wed, 07 Jan 2026 13:12:53 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -368,10 +368,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - db1cc0a6-7014-417e-4cfe-a7ddf447a306
+                - 0a2a7373-7a9c-4fc4-7b0f-a04209f72a17
         status: 200 OK
         code: 200
-        duration: 318.046458ms
+        duration: 339.427458ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -407,7 +407,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:04 GMT
+                - Wed, 07 Jan 2026 13:12:54 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -417,10 +417,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c0c727b5-c8f6-49b8-6610-8634a9580b74
+                - d1316c7f-65f6-434e-595a-5d71cbbd5b42
         status: 204 No Content
         code: 204
-        duration: 754.8975ms
+        duration: 715.230167ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -460,7 +460,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:04 GMT
+                - Wed, 07 Jan 2026 13:12:54 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -470,10 +470,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - df1fe9fd-6164-493d-5b92-3b09a1ab25c1
+                - c4a4a265-8d11-4628-6f78-b05997155d9b
         status: 200 OK
         code: 200
-        duration: 286.038125ms
+        duration: 300.667917ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -505,14 +505,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"subaccount added via terraform tests","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191101729,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727099000,"notBeforeTimeStamp":1758187499000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"subaccount added via terraform tests","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791571496,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327569000,"notBeforeTimeStamp":1767787969000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:04 GMT
+                - Wed, 07 Jan 2026 13:12:54 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -524,10 +524,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1ec7cd30-9c5b-46d2-4042-a051f0c26157
+                - e39d6e18-9ac4-49bc-6142-32f590155135
         status: 200 OK
         code: 200
-        duration: 318.526583ms
+        duration: 342.954709ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -563,7 +563,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:05 GMT
+                - Wed, 07 Jan 2026 13:12:55 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -573,10 +573,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1f660fe0-9707-47a4-4b79-796bbd00568e
+                - d4c01753-78fd-4673-7779-18dbd89cac11
         status: 204 No Content
         code: 204
-        duration: 782.492417ms
+        duration: 589.768ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -616,7 +616,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:06 GMT
+                - Wed, 07 Jan 2026 13:12:55 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -626,10 +626,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 25f25d63-7946-4438-7c4e-097a09a017aa
+                - a70c5414-5998-4164-5b5d-7cfdcbae1a23
         status: 200 OK
         code: 200
-        duration: 298.378ms
+        duration: 304.247541ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -669,7 +669,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:06 GMT
+                - Wed, 07 Jan 2026 13:12:56 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -679,10 +679,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - f9670bbf-7eeb-48c5-6a6c-8f3c5bfb8df3
+                - 517814a1-9fe2-4ac8-6527-843a0e38b612
         status: 200 OK
         code: 200
-        duration: 287.232584ms
+        duration: 348.038917ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -722,7 +722,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:06 GMT
+                - Wed, 07 Jan 2026 13:12:56 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -732,10 +732,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5cb3a642-8f73-409c-4ce7-fc5c7301cf35
+                - dd3089b2-aa46-4fb1-5f5f-b81d0a20932a
         status: 200 OK
         code: 200
-        duration: 285.702542ms
+        duration: 306.0515ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -775,7 +775,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:07 GMT
+                - Wed, 07 Jan 2026 13:12:57 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -785,10 +785,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 348e151b-1633-427d-66a9-0d80d8259bb2
+                - e543b23c-57dc-4bf0-5e74-9e91feb87fe4
         status: 200 OK
         code: 200
-        duration: 286.175584ms
+        duration: 457.382042ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -824,7 +824,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:07 GMT
+                - Wed, 07 Jan 2026 13:12:57 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -834,7 +834,7 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4f4bd558-c435-4ee4-5650-a55ab4bdd284
+                - 92478a11-cf2b-4b92-408e-ce249b414109
         status: 204 No Content
         code: 204
-        duration: 772.810375ms
+        duration: 782.227208ms

--- a/scc/provider/fixtures/resource_subaccount_update.yaml
+++ b/scc/provider/fixtures/resource_subaccount_update.yaml
@@ -40,7 +40,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:08 GMT
+                - Wed, 07 Jan 2026 13:12:59 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -50,10 +50,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 202ba573-e8d5-43f4-6942-cb0d37f1e539
+                - 9deb406f-b91a-4e3b-4675-607e1cddf986
         status: 200 OK
         code: 200
-        duration: 879.850584ms
+        duration: 1.259584876s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -93,7 +93,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:09 GMT
+                - Wed, 07 Jan 2026 13:12:59 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -103,10 +103,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 04f39a84-ba49-42a8-7809-b3d2f4a767e9
+                - 54f48b9e-926b-41e7-7d53-b8a8de45a7c9
         status: 200 OK
         code: 200
-        duration: 287.230584ms
+        duration: 341.467333ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -138,14 +138,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191114253,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727111000,"notBeforeTimeStamp":1758187511000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791585697,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327583000,"notBeforeTimeStamp":1767787983000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:14 GMT
+                - Wed, 07 Jan 2026 13:13:05 GMT
             Location:
                 - redacted
             Server:
@@ -159,10 +159,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c53a8f5c-9c9f-45c5-4e54-824d509bc9ea
+                - 1274aae8-0680-4088-60e2-cc79403ae767
         status: 201 Created
         code: 201
-        duration: 4.958620793s
+        duration: 6.14511196s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -198,7 +198,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:14 GMT
+                - Wed, 07 Jan 2026 13:13:06 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -208,10 +208,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 349ce93f-80ee-4d9b-6de4-eabdc070c1f9
+                - c8992b64-cd99-44b7-5b7e-28511eecefc7
         status: 204 No Content
         code: 204
-        duration: 694.389251ms
+        duration: 593.913667ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -251,7 +251,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:15 GMT
+                - Wed, 07 Jan 2026 13:13:06 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -261,10 +261,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c419db16-28e4-4323-5a25-9fcc69ec748f
+                - f49372ae-7c2e-43aa-6473-97750712c651
         status: 200 OK
         code: 200
-        duration: 287.389292ms
+        duration: 439.817126ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -304,7 +304,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:15 GMT
+                - Wed, 07 Jan 2026 13:13:07 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -314,10 +314,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e0eb9698-13eb-4b8c-7e3e-f8f3c07c53f9
+                - 57d75d18-0e5f-4314-415c-49ad3183adfb
         status: 200 OK
         code: 200
-        duration: 288.83025ms
+        duration: 313.560375ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -349,14 +349,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191114253,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727111000,"notBeforeTimeStamp":1758187511000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791585697,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327583000,"notBeforeTimeStamp":1767787983000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:16 GMT
+                - Wed, 07 Jan 2026 13:13:07 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -368,10 +368,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ae0b5e89-13c3-4b10-4c48-99165af51312
+                - ed66fbc9-dd4f-4151-68a7-ffc5a23dfe47
         status: 200 OK
         code: 200
-        duration: 321.682667ms
+        duration: 327.827125ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -407,7 +407,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:16 GMT
+                - Wed, 07 Jan 2026 13:13:08 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -417,10 +417,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8b0758f2-f14b-4aec-67ec-d7f0db2539a3
+                - 77540dfb-a740-406e-6312-51eaf7a947a3
         status: 204 No Content
         code: 204
-        duration: 721.025458ms
+        duration: 691.323042ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -460,7 +460,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:17 GMT
+                - Wed, 07 Jan 2026 13:13:08 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -470,10 +470,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ce23aa1d-04f9-4da2-4624-1d0652d2e3fa
+                - 0e6bc469-f78d-41f6-68fc-e7797e0ac575
         status: 200 OK
         code: 200
-        duration: 288.1155ms
+        duration: 386.223084ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -505,14 +505,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191114253,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727111000,"notBeforeTimeStamp":1758187511000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791585697,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327583000,"notBeforeTimeStamp":1767787983000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:17 GMT
+                - Wed, 07 Jan 2026 13:13:09 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -524,10 +524,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2d339a94-01a1-4084-415d-61594b7a9c1a
+                - 27514e5a-1cbe-48b7-54ff-753156816e82
         status: 200 OK
         code: 200
-        duration: 319.294916ms
+        duration: 498.92225ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -563,7 +563,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:18 GMT
+                - Wed, 07 Jan 2026 13:13:09 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -573,10 +573,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c5a679d5-f539-4a01-7fb7-737a5b6e8a52
+                - a5b7dc41-e3f2-4070-7733-34ce374e2816
         status: 204 No Content
         code: 204
-        duration: 755.621792ms
+        duration: 716.266333ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -616,7 +616,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:18 GMT
+                - Wed, 07 Jan 2026 13:13:10 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -626,10 +626,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2a5dbd9b-32fb-49dd-6d29-52d0fb5697a6
+                - 9c8401ea-f216-4cd9-6f47-6027ecda0163
         status: 200 OK
         code: 200
-        duration: 286.631626ms
+        duration: 444.465333ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -669,7 +669,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:18 GMT
+                - Wed, 07 Jan 2026 13:13:10 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -679,10 +679,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 175af452-73d5-4a03-6eb5-72886d0bd07b
+                - edc627b0-0642-4484-7051-cc6a819797d8
         status: 200 OK
         code: 200
-        duration: 292.844208ms
+        duration: 461.725126ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -714,14 +714,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191114253,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727111000,"notBeforeTimeStamp":1758187511000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791585697,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327583000,"notBeforeTimeStamp":1767787983000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:19 GMT
+                - Wed, 07 Jan 2026 13:13:11 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -733,10 +733,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 20639105-dddb-4a2a-6dca-d6de2a26189d
+                - affdb246-8072-4977-5d28-ed701a4b9113
         status: 200 OK
         code: 200
-        duration: 318.039875ms
+        duration: 610.322417ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -772,7 +772,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:19 GMT
+                - Wed, 07 Jan 2026 13:13:12 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -782,10 +782,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 03154999-85dc-48fc-67ee-34553b94151e
+                - fa223bcb-6b27-44f0-73a6-c1db8ad299b6
         status: 204 No Content
         code: 204
-        duration: 698.423209ms
+        duration: 782.836083ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -825,7 +825,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:20 GMT
+                - Wed, 07 Jan 2026 13:13:12 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -835,10 +835,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 106f2437-f4e6-4049-5a59-7adb0722a1b7
+                - f950bde1-319b-4879-6c9a-0c9c8de2b7d8
         status: 200 OK
         code: 200
-        duration: 288.4565ms
+        duration: 357.594042ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -870,14 +870,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Updated description","displayName":"Updated Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191114253,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727111000,"notBeforeTimeStamp":1758187511000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Updated description","displayName":"Updated Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791585697,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327583000,"notBeforeTimeStamp":1767787983000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:20 GMT
+                - Wed, 07 Jan 2026 13:13:13 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -889,10 +889,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - fb8e5de4-ea40-44e2-5ec6-b08489238baa
+                - 1e2bef2d-28b8-4236-703c-ffb1180aae69
         status: 200 OK
         code: 200
-        duration: 439.411ms
+        duration: 440.300709ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -928,7 +928,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:21 GMT
+                - Wed, 07 Jan 2026 13:13:13 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -938,10 +938,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 671eb958-a156-4a73-5195-adc9efa3b611
+                - f2795b49-ac23-4df3-7093-4feb0deebecf
         status: 204 No Content
         code: 204
-        duration: 729.767042ms
+        duration: 631.962167ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -981,7 +981,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:21 GMT
+                - Wed, 07 Jan 2026 13:13:14 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -991,10 +991,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 6ce4e915-4d76-49f9-60d9-e6e71fcae0b4
+                - 656cce2c-f1a1-46e0-77e0-9f267c70c370
         status: 200 OK
         code: 200
-        duration: 287.327792ms
+        duration: 412.6455ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1034,7 +1034,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:22 GMT
+                - Wed, 07 Jan 2026 13:13:14 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1044,10 +1044,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 22f20096-325c-4656-778f-0ca902c4e971
+                - c002670b-2fab-40b6-7c80-2467a105dec5
         status: 200 OK
         code: 200
-        duration: 289.069625ms
+        duration: 448.802458ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1079,14 +1079,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Updated description","displayName":"Updated Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1758191114253,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1789727111000,"notBeforeTimeStamp":1758187511000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Updated description","displayName":"Updated Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767791585697,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799327583000,"notBeforeTimeStamp":1767787983000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:22 GMT
+                - Wed, 07 Jan 2026 13:13:15 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1098,10 +1098,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 0a20870d-73a9-46a2-7dd7-70876219a450
+                - a189f0be-a7ac-42a6-7e96-a43e0aded84d
         status: 200 OK
         code: 200
-        duration: 317.012292ms
+        duration: 402.774459ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1137,7 +1137,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:23 GMT
+                - Wed, 07 Jan 2026 13:13:16 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1147,10 +1147,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 11d64922-03d7-41d3-6d17-86e9d606e946
+                - c0b151aa-b1a2-4a89-50cd-e21cbb0bf88c
         status: 204 No Content
         code: 204
-        duration: 745.973209ms
+        duration: 719.57275ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1190,7 +1190,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:23 GMT
+                - Wed, 07 Jan 2026 13:13:16 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1200,10 +1200,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ffe89e2d-c524-408c-4535-4f1690715d5d
+                - 1371b909-003e-41e3-6ebf-d2eb2a9937c5
         status: 200 OK
         code: 200
-        duration: 287.283041ms
+        duration: 336.03825ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1243,7 +1243,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Sep 2025 10:25:23 GMT
+                - Wed, 07 Jan 2026 13:13:16 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1253,10 +1253,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - fcba0616-afea-4f9c-5fcd-c27944374e0f
+                - 85e604c6-cfe5-4c6c-6410-974346b0d8e8
         status: 200 OK
         code: 200
-        duration: 289.810626ms
+        duration: 501.552125ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1292,7 +1292,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Thu, 18 Sep 2025 10:25:24 GMT
+                - Wed, 07 Jan 2026 13:13:17 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1302,7 +1302,7 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ad9e0a83-11cb-40ac-68d4-4bb3c442b1bf
+                - 993c485f-8bf6-45a2-4535-b2fe2f4d1145
         status: 204 No Content
         code: 204
-        duration: 809.120834ms
+        duration: 810.215751ms

--- a/scc/provider/fixtures/resource_subaccount_using_auth.yaml
+++ b/scc/provider/fixtures/resource_subaccount_using_auth.yaml
@@ -40,7 +40,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:21 GMT
+                - Thu, 08 Jan 2026 05:10:52 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -50,10 +50,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 50e22efd-2cf8-4f81-7c58-6814c9dd2952
+                - 9e4b68c6-afc7-45cb-68aa-2d4c7e53c075
         status: 200 OK
         code: 200
-        duration: 1.092322668s
+        duration: 1.1375015s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -93,7 +93,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:22 GMT
+                - Thu, 08 Jan 2026 05:10:53 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -103,10 +103,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 88379599-2cd5-43d2-4f1f-b00b46545159
+                - 6efe5ae7-a6cb-4158-762f-40727af506d6
         status: 200 OK
         code: 200
-        duration: 343.964792ms
+        duration: 292.602208ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -138,14 +138,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"subaccount added via terraform tests","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880886660,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"subaccount added via terraform tests","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849057631,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385055000,"notBeforeTimeStamp":1767845455000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:26 GMT
+                - Thu, 08 Jan 2026 05:10:57 GMT
             Location:
                 - redacted
             Server:
@@ -159,10 +159,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - df407d09-4cb6-42c5-7f87-423b70f189b5
+                - 53dab740-d4e9-4099-6fe7-8fa4c1c6c444
         status: 201 Created
         code: 201
-        duration: 4.492220627s
+        duration: 4.637855418s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -198,7 +198,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:27 GMT
+                - Thu, 08 Jan 2026 05:10:58 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -208,10 +208,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ec7ea568-76ce-4e04-5591-6b8a4c7de588
+                - 055196b9-f524-4ece-79f4-bfecfad02e82
         status: 204 No Content
         code: 204
-        duration: 535.470458ms
+        duration: 784.438959ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -251,7 +251,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:27 GMT
+                - Thu, 08 Jan 2026 05:10:58 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -261,10 +261,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 6c0e3e71-f6ec-4ba2-6893-95bb91a5c153
+                - f220b544-c01f-45fb-5a43-50deda84d03e
         status: 200 OK
         code: 200
-        duration: 275.050459ms
+        duration: 298.091167ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -304,7 +304,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:27 GMT
+                - Thu, 08 Jan 2026 05:10:59 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -314,10 +314,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7545b9e0-6a9d-40fa-6210-ef1ee183d276
+                - 1001d0ea-aedb-484a-7cd6-dca84fa2fc1e
         status: 200 OK
         code: 200
-        duration: 274.383334ms
+        duration: 293.187458ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -349,14 +349,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"subaccount added via terraform tests","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880886660,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"subaccount added via terraform tests","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849057631,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385055000,"notBeforeTimeStamp":1767845455000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:28 GMT
+                - Thu, 08 Jan 2026 05:10:59 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -368,10 +368,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1eeb405f-cd55-41c9-5bc7-caf5a835b5c9
+                - 018c3a19-37c3-409d-6d95-88f2bff9448a
         status: 200 OK
         code: 200
-        duration: 299.812084ms
+        duration: 329.975292ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -407,7 +407,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:28 GMT
+                - Thu, 08 Jan 2026 05:11:00 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -417,10 +417,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8d82ab43-9a95-4f57-5ad8-065f65108bc0
+                - b1076358-b20e-4dd3-573d-71be8747a7b7
         status: 204 No Content
         code: 204
-        duration: 555.958167ms
+        duration: 654.346083ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -460,7 +460,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:29 GMT
+                - Thu, 08 Jan 2026 05:11:00 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -470,10 +470,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e10d2692-620c-4906-5375-a9900f4bf6c5
+                - fd60bec7-d4f6-4f90-4aa5-c0c2b234df78
         status: 200 OK
         code: 200
-        duration: 275.728792ms
+        duration: 300.892167ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -505,14 +505,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"subaccount added via terraform tests","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880886660,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"subaccount added via terraform tests","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849057631,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385055000,"notBeforeTimeStamp":1767845455000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:29 GMT
+                - Thu, 08 Jan 2026 05:11:01 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -524,10 +524,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 518b3742-e4c7-42cb-7e58-4aef85b4f037
+                - c1f5ebb8-58f4-4cf0-49a2-ed59c1c48cde
         status: 200 OK
         code: 200
-        duration: 310.15075ms
+        duration: 327.553416ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -563,7 +563,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:30 GMT
+                - Thu, 08 Jan 2026 05:11:01 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -573,10 +573,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 86085193-7738-46fe-5fc2-e8717363c015
+                - 5d3cf70b-6617-4205-44ff-9b07ff5e08a5
         status: 204 No Content
         code: 204
-        duration: 563.350167ms
+        duration: 660.033542ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -616,7 +616,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:30 GMT
+                - Thu, 08 Jan 2026 05:11:02 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -626,10 +626,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4c4347f8-2728-4177-769d-c10e9dcbce4c
+                - 59f4ffeb-13ac-4d9c-653a-b36bacc928a9
         status: 200 OK
         code: 200
-        duration: 284.735208ms
+        duration: 291.677666ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -669,7 +669,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:30 GMT
+                - Thu, 08 Jan 2026 05:11:02 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -679,10 +679,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - bb956080-df02-4328-514c-1bcfcbb3f666
+                - 0012a992-0edd-4a40-6382-c0741107f823
         status: 200 OK
         code: 200
-        duration: 277.036ms
+        duration: 288.142125ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -722,7 +722,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:31 GMT
+                - Thu, 08 Jan 2026 05:11:02 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -732,10 +732,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8f279694-35e4-4f59-7f82-eb8bd437dd35
+                - bb5caef3-6d4f-42e8-6d81-1574dc99645b
         status: 200 OK
         code: 200
-        duration: 280.948334ms
+        duration: 289.48725ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -775,7 +775,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:31 GMT
+                - Thu, 08 Jan 2026 05:11:03 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -785,10 +785,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 700b72c7-9f12-4281-6ef2-758233a1c326
+                - 36a4182f-0c70-496c-7685-f8eda25fbc1a
         status: 200 OK
         code: 200
-        duration: 275.101875ms
+        duration: 290.13ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -824,7 +824,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:32 GMT
+                - Thu, 08 Jan 2026 05:11:04 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -834,7 +834,7 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 28d2bd4c-e6c3-4285-539f-2e7ca6ad7160
+                - c129442e-23c2-4186-7211-20ca896471e6
         status: 204 No Content
         code: 204
-        duration: 766.993751ms
+        duration: 798.045834ms

--- a/scc/provider/fixtures/resource_subaccount_using_auth_update.yaml
+++ b/scc/provider/fixtures/resource_subaccount_using_auth_update.yaml
@@ -40,7 +40,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:33 GMT
+                - Thu, 08 Jan 2026 05:11:04 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -50,10 +50,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ea1f4fe4-e38c-487b-66dc-b80b10419c34
+                - 0a4f1b61-4774-4c77-4046-fd8622c03d17
         status: 200 OK
         code: 200
-        duration: 852.456958ms
+        duration: 880.602834ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -93,7 +93,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:33 GMT
+                - Thu, 08 Jan 2026 05:11:05 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -103,10 +103,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c2a26109-04c1-4efe-40fd-586a618c24bb
+                - 08cf121b-2516-48ee-4f49-1eaf57e4cbd2
         status: 200 OK
         code: 200
-        duration: 274.148708ms
+        duration: 373.92625ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -138,14 +138,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880897999,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849069764,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385067000,"notBeforeTimeStamp":1767845467000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:38 GMT
+                - Thu, 08 Jan 2026 05:11:09 GMT
             Location:
                 - redacted
             Server:
@@ -159,10 +159,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e15b2451-cb2b-4102-616e-196de7e568bc
+                - 9ea22eae-033d-48cb-4be8-76e6c954df29
         status: 201 Created
         code: 201
-        duration: 4.536122336s
+        duration: 4.363928752s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -198,7 +198,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:38 GMT
+                - Thu, 08 Jan 2026 05:11:10 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -208,10 +208,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - b6e66b17-4e84-4036-562e-783b31517492
+                - b1efb608-c924-40d0-7d60-ea3fdd7668cd
         status: 204 No Content
         code: 204
-        duration: 534.215292ms
+        duration: 829.474417ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -251,7 +251,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:38 GMT
+                - Thu, 08 Jan 2026 05:11:10 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -261,10 +261,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e28987d6-1ceb-4d01-5e3d-34724fe945d3
+                - fbc75466-1e35-4725-57fd-b035b606e6c9
         status: 200 OK
         code: 200
-        duration: 319.138333ms
+        duration: 301.686584ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -304,7 +304,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:39 GMT
+                - Thu, 08 Jan 2026 05:11:11 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -314,10 +314,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e66b29c4-c6b5-4f1d-4370-3eba5addffa9
+                - 898b6ff1-4349-49df-7498-0147c14a5f00
         status: 200 OK
         code: 200
-        duration: 338.849458ms
+        duration: 304.949083ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -349,14 +349,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880897999,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849069764,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385067000,"notBeforeTimeStamp":1767845467000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:39 GMT
+                - Thu, 08 Jan 2026 05:11:11 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -368,10 +368,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e699662e-3f7b-4f5f-4994-79f3542aa8ac
+                - 417c7778-3f49-479d-7f23-15dac7b092c3
         status: 200 OK
         code: 200
-        duration: 304.057375ms
+        duration: 323.772333ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -407,7 +407,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:40 GMT
+                - Thu, 08 Jan 2026 05:11:12 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -417,10 +417,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7d4926d9-3394-4456-6dfb-46655107194f
+                - 7100a1a3-7eb9-4dcb-6129-e754a0853067
         status: 204 No Content
         code: 204
-        duration: 609.760542ms
+        duration: 644.334709ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -460,7 +460,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:40 GMT
+                - Thu, 08 Jan 2026 05:11:12 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -470,10 +470,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e4aa7453-4f92-4b2c-761e-e42fe586fa5e
+                - b4c882ff-67f7-4655-6ba0-44d3cc016df9
         status: 200 OK
         code: 200
-        duration: 314.396417ms
+        duration: 308.994667ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -505,14 +505,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880897999,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Initial description","displayName":"Initial Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849069764,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385067000,"notBeforeTimeStamp":1767845467000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:41 GMT
+                - Thu, 08 Jan 2026 05:11:13 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -524,10 +524,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - d61e6a54-b1cb-4f3b-643c-0f7a1940f1f1
+                - c6d174b5-2c63-4694-4736-53754cc012db
         status: 200 OK
         code: 200
-        duration: 311.38925ms
+        duration: 326.770958ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -563,7 +563,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:41 GMT
+                - Thu, 08 Jan 2026 05:11:13 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -573,10 +573,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - fc428c28-4742-474b-52a9-8915efd271b1
+                - a7038cd2-b265-40f1-6af9-d81b9e553aa6
         status: 204 No Content
         code: 204
-        duration: 566.162375ms
+        duration: 791.779959ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -616,7 +616,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:41 GMT
+                - Thu, 08 Jan 2026 05:11:14 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -626,10 +626,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8fa2d9b2-45f0-456b-4a62-edf1c9b2aefc
+                - 23c9b10f-9629-463b-5d3f-7f307e5f3379
         status: 200 OK
         code: 200
-        duration: 277.741709ms
+        duration: 297.385208ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -661,14 +661,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Updated description","displayName":"Updated Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880897999,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Updated description","displayName":"Updated Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849069764,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385067000,"notBeforeTimeStamp":1767845467000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:42 GMT
+                - Thu, 08 Jan 2026 05:11:14 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -680,10 +680,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1fb663f3-49db-49df-6db0-95b64934ae52
+                - adff23b0-f303-4b1d-60e3-4fe13bb02a0b
         status: 200 OK
         code: 200
-        duration: 392.349333ms
+        duration: 439.280626ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -719,7 +719,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:42 GMT
+                - Thu, 08 Jan 2026 05:11:15 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -729,10 +729,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 37866a13-be29-41b5-5d36-1ae5ef005ed0
+                - 3c8f14da-61f0-419b-72a0-343799f5643e
         status: 204 No Content
         code: 204
-        duration: 537.283834ms
+        duration: 692.080334ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -772,7 +772,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:43 GMT
+                - Thu, 08 Jan 2026 05:11:15 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -782,10 +782,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4c258e69-511d-4914-50dc-ff3f5e3a8847
+                - 0cfd04ed-0095-4eed-5e02-aa0ef64c2315
         status: 200 OK
         code: 200
-        duration: 362.836166ms
+        duration: 290.317292ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -825,7 +825,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:43 GMT
+                - Thu, 08 Jan 2026 05:11:16 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -835,10 +835,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 6aded160-3b3a-4a7e-49bc-08a03ce7d660
+                - 15a9fa18-23b5-4f5f-4e2b-363901c8b4ad
         status: 200 OK
         code: 200
-        duration: 276.392875ms
+        duration: 366.925959ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -870,14 +870,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Updated description","displayName":"Updated Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880897999,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Updated description","displayName":"Updated Display Name","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849069764,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385067000,"notBeforeTimeStamp":1767845467000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:43 GMT
+                - Thu, 08 Jan 2026 05:11:16 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -889,10 +889,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7d3af7df-b4b0-4c44-7a27-e80276fe9b27
+                - b6ec6183-d0e8-4972-5b07-1397beb1409e
         status: 200 OK
         code: 200
-        duration: 360.331542ms
+        duration: 323.948041ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -928,7 +928,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:44 GMT
+                - Thu, 08 Jan 2026 05:11:17 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -938,10 +938,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4e9aa504-60f1-4ba0-620b-bcd492610099
+                - 7250d35c-f63e-422d-7fc5-14cf40443dc3
         status: 204 No Content
         code: 204
-        duration: 715.226ms
+        duration: 617.007001ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -981,7 +981,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:45 GMT
+                - Thu, 08 Jan 2026 05:11:17 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -991,10 +991,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c61b6bcd-05d0-46cf-4f9b-1ddc6795c660
+                - 14cb67a0-d1b6-4fc9-6d19-3db8cd68666e
         status: 200 OK
         code: 200
-        duration: 307.452833ms
+        duration: 293.496459ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1034,7 +1034,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:45 GMT
+                - Thu, 08 Jan 2026 05:11:17 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1044,10 +1044,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - a8c8a839-7afc-4472-68b6-985907a88859
+                - e9e6f6e2-d1d6-45c4-6ea5-3858ddc8328e
         status: 200 OK
         code: 200
-        duration: 278.57875ms
+        duration: 309.404084ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1083,7 +1083,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:46 GMT
+                - Thu, 08 Jan 2026 05:11:18 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1093,7 +1093,7 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ff905de3-bfcf-433b-4b0b-d47d8b70eddb
+                - 123c6f76-6a11-48be-472d-9f7bcfd30bf1
         status: 204 No Content
         code: 204
-        duration: 759.774125ms
+        duration: 822.773084ms

--- a/scc/provider/fixtures/resource_subaccount_using_auth_update_tunnel.yaml
+++ b/scc/provider/fixtures/resource_subaccount_using_auth_update_tunnel.yaml
@@ -40,7 +40,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:47 GMT
+                - Thu, 08 Jan 2026 05:11:19 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -50,10 +50,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 154f27fe-77d7-44a3-69cc-8dc08338c2b3
+                - a5b0fad6-8a62-4817-7bd8-4eb9a302aa22
         status: 200 OK
         code: 200
-        duration: 788.466917ms
+        duration: 858.497625ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -93,7 +93,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:47 GMT
+                - Thu, 08 Jan 2026 05:11:20 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -103,10 +103,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 34ae515a-c5e9-4be2-5a3a-f6917ef2f283
+                - 86e07057-ab30-418d-58dd-11b12bd78ec7
         status: 200 OK
         code: 200
-        duration: 267.995208ms
+        duration: 301.210667ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -138,14 +138,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel connected","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880911916,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel connected","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849084802,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:51 GMT
+                - Thu, 08 Jan 2026 05:11:24 GMT
             Location:
                 - redacted
             Server:
@@ -159,10 +159,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 17af3ddb-3e3b-4055-4121-66df92cf048b
+                - d65a4f9c-b045-4a38-6675-6089058b4387
         status: 201 Created
         code: 201
-        duration: 4.512065003s
+        duration: 4.896099753s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -198,7 +198,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:52 GMT
+                - Thu, 08 Jan 2026 05:11:25 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -208,10 +208,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e169cbd3-9ad8-48cb-65c4-e75eb2d0d954
+                - 705ec3b2-7736-478c-6a39-f05e4dce27dd
         status: 204 No Content
         code: 204
-        duration: 498.072875ms
+        duration: 612.155708ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -251,7 +251,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:52 GMT
+                - Thu, 08 Jan 2026 05:11:25 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -261,10 +261,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 78b54554-ae94-4294-63fb-9dc51184a90b
+                - 69228edf-2904-483c-5964-2f3bab587b42
         status: 200 OK
         code: 200
-        duration: 292.594958ms
+        duration: 299.969709ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -304,7 +304,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:53 GMT
+                - Thu, 08 Jan 2026 05:11:26 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -314,10 +314,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 3996027c-6a07-4296-4d7f-028ab12bd9a0
+                - 3967d002-d0b1-4f8f-6c59-277c4b79fa68
         status: 200 OK
         code: 200
-        duration: 266.207126ms
+        duration: 299.57875ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -349,14 +349,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel connected","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880911916,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel connected","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849084802,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:53 GMT
+                - Thu, 08 Jan 2026 05:11:26 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -368,10 +368,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - bf92aa46-16e8-4ff7-5c05-e575e95c2b07
+                - e7184c7f-7f7b-40f5-6576-06c878dcf9c8
         status: 200 OK
         code: 200
-        duration: 303.053917ms
+        duration: 338.044167ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -407,7 +407,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:54 GMT
+                - Thu, 08 Jan 2026 05:11:27 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -417,10 +417,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - bfceddbd-71db-42a1-4496-c0c625e33616
+                - 240e278a-3fb3-4531-4691-59032ee068bb
         status: 204 No Content
         code: 204
-        duration: 579.067208ms
+        duration: 608.889709ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -460,7 +460,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:54 GMT
+                - Thu, 08 Jan 2026 05:11:27 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -470,10 +470,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - cbf1797d-6b37-479e-70e5-c8bdd461be39
+                - 439553fd-8db4-44af-4e17-5aa08538539e
         status: 200 OK
         code: 200
-        duration: 277.904209ms
+        duration: 308.903792ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -505,14 +505,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel connected","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880911916,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel connected","displayName":"terraform-cloud-connector-subaccount-87pt0qgr","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849084802,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:54 GMT
+                - Thu, 08 Jan 2026 05:11:27 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -524,10 +524,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2ab5ff9c-4cd2-45c5-4720-6fa4f583e5d1
+                - 4043b301-f0e9-49d5-5e0c-8b33bdcfabff
         status: 200 OK
         code: 200
-        duration: 302.703709ms
+        duration: 348.292542ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -563,7 +563,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:55 GMT
+                - Thu, 08 Jan 2026 05:11:28 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -573,10 +573,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1e376e28-81a9-45b5-77e6-045efef61433
+                - 39dddfc5-105a-42ac-7818-cb11eae6b25a
         status: 204 No Content
         code: 204
-        duration: 576.568542ms
+        duration: 663.209376ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -616,7 +616,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:55 GMT
+                - Thu, 08 Jan 2026 05:11:28 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -626,10 +626,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 82e01e2f-ff72-4187-7005-0aab76001503
+                - adb21ed2-4438-465e-708e-a9aa87495d2d
         status: 200 OK
         code: 200
-        duration: 273.417625ms
+        duration: 296.372334ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -661,14 +661,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel disconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880911916,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel disconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849084802,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:56 GMT
+                - Thu, 08 Jan 2026 05:11:29 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -680,10 +680,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 64262c0c-759e-406d-55f9-eb44ba9b23cc
+                - 51df77da-027c-4fcf-5933-1aa7e4c6acc7
         status: 200 OK
         code: 200
-        duration: 383.487459ms
+        duration: 417.121292ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -719,7 +719,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:56 GMT
+                - Thu, 08 Jan 2026 05:11:29 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -729,10 +729,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1c5c8eb0-7f46-4762-7a1a-12f69169290e
+                - f43791b0-fc5f-4693-76b9-980aa62eaccf
         status: 204 No Content
         code: 204
-        duration: 344.497167ms
+        duration: 378.457667ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -764,14 +764,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel disconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Disconnected","connectedSinceTimeStamp":0,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel disconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Disconnected","connectedSinceTimeStamp":0,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:56 GMT
+                - Thu, 08 Jan 2026 05:11:30 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -783,10 +783,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 51b3a470-da5c-4f50-6b49-d61352707c9c
+                - bc8598e1-710f-4158-7012-5b969c28b975
         status: 200 OK
         code: 200
-        duration: 286.860125ms
+        duration: 318.462625ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -826,7 +826,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:56 GMT
+                - Thu, 08 Jan 2026 05:11:30 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -836,10 +836,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5aa6ad83-d543-4a49-70e4-509bf2b54a71
+                - 8f4229b4-af58-4699-7225-8133484d076a
         status: 200 OK
         code: 200
-        duration: 277.174834ms
+        duration: 308.118791ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -879,7 +879,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:57 GMT
+                - Thu, 08 Jan 2026 05:11:30 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -889,10 +889,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4d62d079-67ae-4d13-4e8e-ca38e778234c
+                - 9146f665-1fd3-48b4-7296-efb0897392f4
         status: 200 OK
         code: 200
-        duration: 271.192667ms
+        duration: 345.558834ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -924,14 +924,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel disconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Disconnected","connectedSinceTimeStamp":0,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel disconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Disconnected","connectedSinceTimeStamp":0,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:57 GMT
+                - Thu, 08 Jan 2026 05:11:31 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -943,10 +943,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 47822ee2-4d44-4db9-4f34-295b842b5e99
+                - ff382ea2-19a4-4e2e-4b3f-d2a067b0ad4a
         status: 200 OK
         code: 200
-        duration: 297.973ms
+        duration: 326.753792ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -986,7 +986,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:57 GMT
+                - Thu, 08 Jan 2026 05:11:31 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -996,10 +996,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - cb94ada9-c5a2-4de0-5ed7-5bcc3e6de249
+                - 75f32747-5544-4104-57ac-52ce380d6c0e
         status: 200 OK
         code: 200
-        duration: 267.06975ms
+        duration: 291.459833ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1031,14 +1031,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel disconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Disconnected","connectedSinceTimeStamp":0,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel disconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Disconnected","connectedSinceTimeStamp":0,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:58 GMT
+                - Thu, 08 Jan 2026 05:11:31 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1050,10 +1050,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 12e29be8-c456-4eb5-773c-a1f441fcde7f
+                - 584cc9a5-45df-4c1c-7a26-8725bdd144a5
         status: 200 OK
         code: 200
-        duration: 290.322292ms
+        duration: 379.841833ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1093,7 +1093,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:58 GMT
+                - Thu, 08 Jan 2026 05:11:32 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1103,10 +1103,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 6dd8af4f-aeab-4377-46f5-7acef4e13193
+                - 90484351-81ff-4c8d-410b-b4865a9c49a8
         status: 200 OK
         code: 200
-        duration: 267.70975ms
+        duration: 295.5385ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1138,14 +1138,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel reconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Disconnected","connectedSinceTimeStamp":0,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel reconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Disconnected","connectedSinceTimeStamp":0,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:59 GMT
+                - Thu, 08 Jan 2026 05:11:32 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1157,10 +1157,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 0d823dce-15af-4c29-76e3-40d28f432167
+                - 751db38e-f524-4b43-6cc8-5e816e9f21c3
         status: 200 OK
         code: 200
-        duration: 401.167875ms
+        duration: 431.100917ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1196,7 +1196,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:41:59 GMT
+                - Thu, 08 Jan 2026 05:11:33 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1206,10 +1206,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 0b49d877-8efe-49ad-6297-d125e2bafc04
+                - 3fd493b2-7fdc-4eb6-4a58-803c33c32180
         status: 204 No Content
         code: 204
-        duration: 641.166667ms
+        duration: 748.909667ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1241,14 +1241,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel reconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880919661,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel reconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849093486,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:41:59 GMT
+                - Thu, 08 Jan 2026 05:11:33 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1260,10 +1260,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5e575684-d569-4e35-55c8-7a6b6c2df2fd
+                - 435ac9fb-b299-411e-406c-9e28dc6da4a1
         status: 200 OK
         code: 200
-        duration: 293.427292ms
+        duration: 330.844625ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:42:00 GMT
+                - Thu, 08 Jan 2026 05:11:34 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1309,10 +1309,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c47dc6c2-c8f4-48ae-77e6-c92649d5ecd9
+                - 8d7e5e07-7e19-4e98-782f-7c6fc219de2e
         status: 204 No Content
         code: 204
-        duration: 547.398917ms
+        duration: 646.970334ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1352,7 +1352,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:42:00 GMT
+                - Thu, 08 Jan 2026 05:11:34 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1362,10 +1362,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 29c62176-85cc-4ffa-768f-e063a2a734a8
+                - 4e79caae-8965-4a7b-5005-283ca650d762
         status: 200 OK
         code: 200
-        duration: 268.247209ms
+        duration: 293.670625ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1405,7 +1405,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:42:01 GMT
+                - Thu, 08 Jan 2026 05:11:35 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1415,10 +1415,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 3a4145a8-4b4a-4cfc-6cb7-70811ecd7502
+                - 2e783510-7280-492a-4607-626002c427c7
         status: 200 OK
         code: 200
-        duration: 267.266166ms
+        duration: 292.293584ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1450,14 +1450,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"description":"Testing tunnel reconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1755880919661,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp": 1111111111111,"notBeforeTimeStamp": 1111111111111,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
+        body: '{"description":"Testing tunnel reconnected","displayName":"4916a705-273c-45a6-a2f0-08c234c7a23d","tunnel":{"state":"Connected","connectedSinceTimeStamp":1767849093486,"connections":0,"applicationConnections":[],"serviceChannels":[],"subaccountCertificate":{"notAfterTimeStamp":1799385082000,"notBeforeTimeStamp":1767845482000,"subjectDN": "CN=redacted,L=redacted,OU=redacted,OU=redacted,O=redacted,C=redacted","issuer": "CN=redacted,OU=SAP Cloud Platform Clients,O=redacted,L=redacted,C=redacted","serialNumber": "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"},"user":"cloud-user@example.com"},"_links":{"ABAPCloud-channels":{"href": "https://redacted.url/path"},"HANA-channels":{"href": "https://redacted.url/path"},"systemMappings":{"href": "https://redacted.url/path"},"self":{"href": "https://redacted.url/path"},"K8S-channels":{"href": "https://redacted.url/path"},"validity":{"href": "https://redacted.url/path"},"state":{"href": "https://redacted.url/path"},"VirtualMachine-channels":{"href": "https://redacted.url/path"},"domainMappings":{"href": "https://redacted.url/path"}},"regionHost":"cf.eu12.hana.ondemand.com","subaccount":"4916a705-273c-45a6-a2f0-08c234c7a23d","locationID":""}'
         headers:
             Cache-Control:
                 - no-store
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:42:01 GMT
+                - Thu, 08 Jan 2026 05:11:35 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1469,10 +1469,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 05bfde43-d30c-4409-6f01-427bdec57dd8
+                - a606ac8f-8bbc-449a-5d40-5ffe2cac0a06
         status: 200 OK
         code: 200
-        duration: 300.512667ms
+        duration: 325.578167ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1508,7 +1508,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:42:02 GMT
+                - Thu, 08 Jan 2026 05:11:36 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1518,10 +1518,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - b6f2f17f-4b80-4c12-6e13-12443b6de3d8
+                - 735ba144-5ed0-4747-7169-85f8fe7a6291
         status: 204 No Content
         code: 204
-        duration: 545.910958ms
+        duration: 614.1235ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1561,7 +1561,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:42:02 GMT
+                - Thu, 08 Jan 2026 05:11:36 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1571,10 +1571,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - f34b7909-0ffd-4f53-6af7-307037514f8a
+                - 6db1a5bc-a914-4336-40b6-0deaa40c8579
         status: 200 OK
         code: 200
-        duration: 266.531917ms
+        duration: 291.272417ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1614,7 +1614,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 22 Aug 2025 16:42:02 GMT
+                - Thu, 08 Jan 2026 05:11:36 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1624,10 +1624,10 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2279124e-7be4-4578-40df-9166eb47900a
+                - 834aef99-c214-44c1-731c-644695541d7d
         status: 200 OK
         code: 200
-        duration: 273.510375ms
+        duration: 289.092959ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1663,7 +1663,7 @@ interactions:
             Cache-Control:
                 - no-store
             Date:
-                - Fri, 22 Aug 2025 16:42:03 GMT
+                - Thu, 08 Jan 2026 05:11:37 GMT
             Server:
                 - nginx/1.27.4
             Set-Cookie:
@@ -1673,7 +1673,7 @@ interactions:
             X-Csrf-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c9f3d6d8-3b12-4673-77bd-7e65f8959fee
+                - 480d34e5-8cc8-4ea1-4130-6f959f82a7e4
         status: 204 No Content
         code: 204
-        duration: 708.3805ms
+        duration: 753.443042ms

--- a/scc/provider/resource_subaccount_test.go
+++ b/scc/provider/resource_subaccount_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -50,6 +52,15 @@ func TestResourceSubaccount(t *testing.T) {
 						resource.TestMatchResourceAttr("scc_subaccount.test", "tunnel.subaccount_certificate.serial_number", regexValidSerialNumber),
 						resource.TestMatchResourceAttr("scc_subaccount.test", "tunnel.subaccount_certificate.subject_dn", regexp.MustCompile(`CN=.*?,L=.*?,OU=.*?,OU=.*?,O=.*?,C=.*?`)),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount.test",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact("cf.eu12.hana.ondemand.com"),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 				{
 					ResourceName:                         "scc_subaccount.test",
@@ -98,6 +109,15 @@ func TestResourceSubaccount(t *testing.T) {
 						resource.TestCheckResourceAttr("scc_subaccount.test", "description", "Initial description"),
 						resource.TestCheckResourceAttr("scc_subaccount.test", "display_name", "Initial Display Name"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount.test",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact("cf.eu12.hana.ondemand.com"),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 				// Update with mismatched configuration should throw error
 				{

--- a/scc/provider/resource_subaccount_using_auth_test.go
+++ b/scc/provider/resource_subaccount_using_auth_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -44,6 +46,15 @@ func TestResourceSubaccountUsingAuth(t *testing.T) {
 						resource.TestMatchResourceAttr("scc_subaccount_using_auth.test", "tunnel.subaccount_certificate.serial_number", regexValidSerialNumber),
 						resource.TestMatchResourceAttr("scc_subaccount_using_auth.test", "tunnel.subaccount_certificate.subject_dn", regexp.MustCompile(`CN=.*?,L=.*?,OU=.*?,OU=.*?,O=.*?,C=.*?`)),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount_using_auth.test",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact("cf.eu12.hana.ondemand.com"),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 				{
 					ResourceName:                         "scc_subaccount_using_auth.test",
@@ -98,6 +109,15 @@ func TestResourceSubaccountUsingAuth(t *testing.T) {
 						resource.TestCheckResourceAttr("scc_subaccount_using_auth.test", "description", "Updated description"),
 						resource.TestCheckResourceAttr("scc_subaccount_using_auth.test", "display_name", "Updated Display Name"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount_using_auth.test",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact("cf.eu12.hana.ondemand.com"),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 			},
 		})
@@ -119,18 +139,45 @@ func TestResourceSubaccountUsingAuth(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("scc_subaccount_using_auth.test", "tunnel.state", "Connected"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount_using_auth.test",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact("cf.eu12.hana.ondemand.com"),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 				{
 					Config: providerConfig(user) + ResourceSubaccountUsingAuthWithTunnelState("test", user.CloudAuthenticationData, "Testing tunnel disconnected", false),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("scc_subaccount_using_auth.test", "tunnel.state", "Disconnected"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount_using_auth.test",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact("cf.eu12.hana.ondemand.com"),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 				{
 					Config: providerConfig(user) + ResourceSubaccountUsingAuthWithTunnelState("test", user.CloudAuthenticationData, "Testing tunnel reconnected", true),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("scc_subaccount_using_auth.test", "tunnel.state", "Connected"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount_using_auth.test",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact("cf.eu12.hana.ondemand.com"),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 			},
 		})


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Add import identities support for subaccount and subaccount using auth resources 
- Closes https://github.com/SAP/terraform-provider-scc/issues/201

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
During the read operation executed as part of the import, some fields return null values. These fields are defined as computed, but the provider does not currently handle these null values correctly. As a result, Terraform detects differences between the imported state and the provider state, which leads to an unintended update being planned or executed. 
Will be Fixed as part of this issue: https://github.com/SAP/terraform-provider-scc/issues/206

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
