### PR TITLE
fix: set identity data during update

### DIFF
--- a/scc/provider/resource_domain_mapping.go
+++ b/scc/provider/resource_domain_mapping.go
@@ -278,6 +278,15 @@ func (r *DomainMappingResource) Update(ctx context.Context, req resource.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	identity := domainMappingResourceIdentityModel{
+		Subaccount:     state.Subaccount,
+		RegionHost:     state.RegionHost,
+		InternalDomain: state.InternalDomain,
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
 }
 
 func (r *DomainMappingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/scc/provider/resource_subaccount.go
+++ b/scc/provider/resource_subaccount.go
@@ -522,6 +522,14 @@ func (r *SubaccountResource) Update(ctx context.Context, req resource.UpdateRequ
 	responseModel.AutoRenewBeforeDays = plan.AutoRenewBeforeDays
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, responseModel)...)
+
+	identity := subaccountResourceIdentityModel{
+		Subaccount: state.Subaccount,
+		RegionHost: state.RegionHost,
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
 }
 
 func appendAndCheckErrors(diags *diag.Diagnostics, newDiags diag.Diagnostics) bool {

--- a/scc/provider/resource_subaccount_abap_service_channel.go
+++ b/scc/provider/resource_subaccount_abap_service_channel.go
@@ -345,6 +345,15 @@ func (r *SubaccountABAPServiceChannelResource) Update(ctx context.Context, req r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	identity := subaccountABAPServiceChannelResourceIdentityModel{
+		Subaccount: state.Subaccount,
+		RegionHost: state.RegionHost,
+		ID:         state.ID,
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
 }
 
 func (r *SubaccountABAPServiceChannelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/scc/provider/resource_subaccount_abap_service_channel_test.go
+++ b/scc/provider/resource_subaccount_abap_service_channel_test.go
@@ -140,6 +140,21 @@ func TestResourceSubaccountABAPServiceChannel(t *testing.T) {
 						resource.TestCheckResourceAttr("scc_subaccount_abap_service_channel.scc_abap_sc", "connections", "2"),
 						resource.TestCheckResourceAttr("scc_subaccount_abap_service_channel.scc_abap_sc", "enabled", "false"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount_abap_service_channel.scc_abap_sc",
+							map[string]knownvalue.Check{
+								"id": knownvalue.Int64Func(func(v int64) error {
+									if v <= 0 {
+										return fmt.Errorf("id should be positive, got %d", v)
+									}
+									return nil
+								}),
+								"region_host": knownvalue.StringExact(regionHost),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 			},
 		})

--- a/scc/provider/resource_subaccount_k8s_service_channel.go
+++ b/scc/provider/resource_subaccount_k8s_service_channel.go
@@ -342,6 +342,15 @@ func (r *SubaccountK8SServiceChannelResource) Update(ctx context.Context, req re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	identity := subaccountK8SServiceChannelResourceIdentityModel{
+		Subaccount: state.Subaccount,
+		RegionHost: state.RegionHost,
+		ID:         state.ID,
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
 }
 
 func (r *SubaccountK8SServiceChannelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/scc/provider/resource_subaccount_test.go
+++ b/scc/provider/resource_subaccount_test.go
@@ -56,7 +56,7 @@ func TestResourceSubaccount(t *testing.T) {
 						statecheck.ExpectIdentity(
 							"scc_subaccount.scc_sa",
 							map[string]knownvalue.Check{
-								"region_host": knownvalue.StringExact("cf.eu12.hana.ondemand.com"),
+								"region_host": knownvalue.StringExact(regionHost),
 								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
 							},
 						),
@@ -130,6 +130,15 @@ func TestResourceSubaccount(t *testing.T) {
 						resource.TestCheckResourceAttr("scc_subaccount.scc_sa", "description", "Updated description"),
 						resource.TestCheckResourceAttr("scc_subaccount.scc_sa", "display_name", "Updated Display Name"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount.scc_sa",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact(regionHost),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 			},
 		})
@@ -151,6 +160,15 @@ func TestResourceSubaccount(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("scc_subaccount.scc_sa", "tunnel.state", "Connected"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount.scc_sa",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact(regionHost),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 				// Update with mismatched configuration should throw error
 				{
@@ -162,12 +180,30 @@ func TestResourceSubaccount(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("scc_subaccount.scc_sa", "tunnel.state", "Disconnected"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount.scc_sa",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact(regionHost),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 				{
 					Config: providerConfig(user) + ResourceSubaccountWithTunnelState("scc_sa", regionHost, subaccount, user.CloudUsername, user.CloudPassword, "Testing tunnel reconnected", true),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("scc_subaccount.scc_sa", "tunnel.state", "Connected"),
 					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectIdentity(
+							"scc_subaccount.scc_sa",
+							map[string]knownvalue.Check{
+								"region_host": knownvalue.StringExact(regionHost),
+								"subaccount":  knownvalue.StringRegexp(regexpValidUUID),
+							},
+						),
+					},
 				},
 			},
 		})

--- a/scc/provider/resource_subaccount_using_auth.go
+++ b/scc/provider/resource_subaccount_using_auth.go
@@ -450,6 +450,13 @@ func (r *SubaccountUsingAuthResource) Update(ctx context.Context, req resource.U
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, responseModel)...)
 
+	identity := subaccountUsingAuthResourceIdentityModel{
+		Subaccount: state.Subaccount,
+		RegionHost: state.RegionHost,
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
 }
 
 func appendAndCheckErrorsCopy(diags *diag.Diagnostics, newDiags diag.Diagnostics) bool {

--- a/scc/provider/resource_system_mapping.go
+++ b/scc/provider/resource_system_mapping.go
@@ -488,6 +488,16 @@ func (r *SystemMappingResource) Update(ctx context.Context, req resource.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	identity := systemMappingResourceIdentityModel{
+		Subaccount:  state.Subaccount,
+		RegionHost:  state.RegionHost,
+		VirtualHost: state.VirtualHost,
+		VirtualPort: state.VirtualPort,
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
 }
 
 func (r *SystemMappingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/scc/provider/resource_system_mapping_resource.go
+++ b/scc/provider/resource_system_mapping_resource.go
@@ -319,6 +319,17 @@ func (r *SystemMappingResourceResource) Update(ctx context.Context, req resource
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	identity := systemMappingResourceResourceIdentityModel{
+		Subaccount:  state.Subaccount,
+		RegionHost:  state.RegionHost,
+		VirtualHost: state.VirtualHost,
+		VirtualPort: state.VirtualPort,
+		URLPath:     state.URLPath,
+	}
+
+	diags = resp.Identity.Set(ctx, identity)
+	resp.Diagnostics.Append(diags...)
 }
 
 func (r *SystemMappingResourceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- ensure identity data is populated during the update process
- closes https://github.com/SAP/terraform-provider-scc/issues/250

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
