### PR TITLE
feat: Fix base URL path handling to support APIM proxy (preserve instance_url)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
@@ -156,11 +157,17 @@ func (c *RestApiClient) DoRequest(method string, endpoint string, body []byte, a
 		return nil, diags
 	}
 
-	finalURL := c.BaseURL.ResolveReference(endpointURL)
+	// Path joining preserves any base path on instance_url so that proxy deployments
+	// with a URL prefix (e.g. "https://host/xp264-scc") work correctly.
+	// Slashes are trimmed on both sides before joining to prevent double-slashes
+	// (e.g. base="/xp264-scc/" + endpoint="/api/resource" → "/xp264-scc/api/resource").
+	baseURL := *c.BaseURL
+	baseURL.Path = strings.TrimRight(baseURL.Path, "/") + "/" + strings.TrimLeft(endpointURL.Path, "/")
+	baseURL.RawQuery = endpointURL.RawQuery
 
-	req, err := http.NewRequest(method, finalURL.String(), bytes.NewBuffer(body))
+	req, err := http.NewRequest(method, baseURL.String(), bytes.NewBuffer(body))
 	if err != nil {
-		diags.AddError("Failed to Create Request", fmt.Sprintf("Error creating request for %s %s: %v", method, finalURL.String(), err))
+		diags.AddError("Failed to Create Request", fmt.Sprintf("Error creating request for %s %s: %v", method, baseURL.String(), err))
 		return nil, diags
 	}
 
@@ -184,7 +191,7 @@ func (c *RestApiClient) DoRequest(method string, endpoint string, body []byte, a
 
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		diags.AddError("Request Failed", fmt.Sprintf("Error sending %s request to %s: %v", method, finalURL.String(), err))
+		diags.AddError("Request Failed", fmt.Sprintf("Error sending %s request to %s: %v", method, baseURL.String(), err))
 		return nil, diags
 	}
 	validateDiags := validateResponse(resp)

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -320,3 +320,197 @@ func TestRestApiClient_DoRequest_BinaryResponse(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, []byte{0x01, 0x02, 0x03}, body)
 }
+
+func buildFinalURL(base *url.URL, endpoint string) string {
+	endpointURL, _ := url.Parse(endpoint)
+
+	baseCopy := *base
+	baseCopy.Path = strings.TrimRight(baseCopy.Path, "/") + "/" + strings.TrimLeft(endpointURL.Path, "/")
+	baseCopy.RawQuery = endpointURL.RawQuery
+
+	return baseCopy.String()
+}
+
+func TestURLJoin_WithBasePath(t *testing.T) {
+	base, _ := url.Parse("https://example.com/xp264-scc")
+
+	result := buildFinalURL(base, "/api/v1/test")
+
+	expected := "https://example.com/xp264-scc/api/v1/test"
+
+	if result != expected {
+		t.Fatalf("expected %s, got %s", expected, result)
+	}
+}
+
+func TestURLJoin_NoBasePath(t *testing.T) {
+	base, _ := url.Parse("https://example.com")
+
+	result := buildFinalURL(base, "/api/v1/test")
+
+	expected := "https://example.com/api/v1/test"
+
+	if result != expected {
+		t.Fatalf("expected %s, got %s", expected, result)
+	}
+}
+
+func TestURLJoin_QueryParams(t *testing.T) {
+	base, _ := url.Parse("https://example.com/xp264-scc")
+
+	result := buildFinalURL(base, "/api/v1/test?foo=bar")
+
+	expected := "https://example.com/xp264-scc/api/v1/test?foo=bar"
+
+	if result != expected {
+		t.Fatalf("expected %s, got %s", expected, result)
+	}
+}
+
+func TestDoRequest_APIMPathPreserved(t *testing.T) {
+	var receivedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	base, _ := url.Parse(server.URL + "/xp264-scc")
+
+	client := &RestApiClient{
+		BaseURL: base,
+		Client:  server.Client(),
+	}
+
+	_, diags := client.GetRequest("/api/v1/connector/version")
+	if diags.HasError() {
+		t.Fatalf("unexpected error: %v", diags)
+	}
+
+	expected := "/xp264-scc/api/v1/connector/version"
+
+	if receivedPath != expected {
+		t.Fatalf("expected path %s, got %s", expected, receivedPath)
+	}
+}
+
+func TestDoRequest_NoBasePath(t *testing.T) {
+	var receivedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	base, _ := url.Parse(server.URL)
+
+	client := &RestApiClient{
+		BaseURL: base,
+		Client:  server.Client(),
+	}
+
+	_, diags := client.GetRequest("/api/v1/connector/version")
+	if diags.HasError() {
+		t.Fatalf("unexpected error: %v", diags)
+	}
+
+	expected := "/api/v1/connector/version"
+
+	if receivedPath != expected {
+		t.Fatalf("expected path %s, got %s", expected, receivedPath)
+	}
+}
+
+func TestDoRequest_QueryParamsPreserved(t *testing.T) {
+	var receivedPath string
+	var receivedQuery string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedQuery = r.URL.RawQuery
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	base, _ := url.Parse(server.URL + "/xp264-scc")
+
+	client := &RestApiClient{
+		BaseURL: base,
+		Client:  server.Client(),
+	}
+
+	_, diags := client.GetRequest("/api/v1/test?foo=bar&x=1")
+	require.False(t, diags.HasError())
+
+	assert.Equal(t, "/xp264-scc/api/v1/test", receivedPath)
+	assert.Equal(t, "foo=bar&x=1", receivedQuery)
+}
+
+func TestDoRequest_EmptyEndpoint(t *testing.T) {
+	var receivedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	base, _ := url.Parse(server.URL + "/xp264-scc")
+
+	client := &RestApiClient{
+		BaseURL: base,
+		Client:  server.Client(),
+	}
+
+	_, diags := client.GetRequest("")
+	require.False(t, diags.HasError())
+
+	assert.Equal(t, "/xp264-scc/", receivedPath)
+}
+
+func TestDoRequest_NoLeadingSlash(t *testing.T) {
+	var receivedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	base, _ := url.Parse(server.URL + "/xp264-scc")
+
+	client := &RestApiClient{
+		BaseURL: base,
+		Client:  server.Client(),
+	}
+
+	_, diags := client.GetRequest("api/v1/test")
+	require.False(t, diags.HasError())
+
+	assert.Equal(t, "/xp264-scc/api/v1/test", receivedPath)
+}
+
+func TestDoRequest_BaseQueryPreserved(t *testing.T) {
+	var receivedQuery string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	base, _ := url.Parse(server.URL + "/xp264-scc?base=1")
+
+	client := &RestApiClient{
+		BaseURL: base,
+		Client:  server.Client(),
+	}
+
+	_, diags := client.GetRequest("/api/v1/test?foo=bar")
+	require.False(t, diags.HasError())
+
+	// Decide behavior: override OR merge
+	assert.Equal(t, "foo=bar", receivedQuery)
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Closes: https://github.com/SAP/terraform-provider-scc/issues/170
- Fixes construction of URL by preserving the base path in instance_url instead of replacing it. This allows the provider to work with APIM-based proxy endpoints.
- Added unit tests to check cases such as: path preserved, no base path, query params preserved, empty endpoint.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
