### PR TITLE
feat: Added skip_ssl_validation attribute to provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,6 @@ Use **file(\"path/to/client_key.pem\")** in the provider block to load from a fi
 - This key must match the client certificate provided in client_certificate attribute.
 - `instance_url` (String) The URL of the Cloud Connector instance. This can also be sourced from the `SCC_INSTANCE_URL` environment variable.
 - `password` (String, Sensitive) The password used for Basic Authentication with the Cloud Connector instance. This can also be sourced from the `SCC_PASSWORD` environment variable (useful when storing and retrieving secrets from secure stores).
-- `skip_ssl_validation` (Boolean) Whether to skip SSL certificate validation when connecting to the Cloud Connector instance. This is not recommended for production use. Defaults to false.
+- `skip_ssl_validation` (Boolean) Whether to skip SSL certificate validation when connecting to the Cloud Connector instance. This can also be sourced from the `SCC_SKIP_SSL_VALIDATION` environment variable. This is not recommended for production use. Defaults to false.
 - `username` (String) The username used for Basic Authentication with the Cloud Connector instance. This can also be sourced from the `SCC_USERNAME` environment variable (useful when storing and retrieving secrets from secure stores).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,5 +62,6 @@ Use **file(\"path/to/client_key.pem\")** in the provider block to load from a fi
 - This key must match the client certificate provided in client_certificate attribute.
 - `instance_url` (String) The URL of the Cloud Connector instance. This can also be sourced from the `SCC_INSTANCE_URL` environment variable.
 - `password` (String, Sensitive) The password used for Basic Authentication with the Cloud Connector instance. This can also be sourced from the `SCC_PASSWORD` environment variable (useful when storing and retrieving secrets from secure stores).
+- `skip_ssl_validation` (Boolean) Whether to skip SSL certificate validation when connecting to the Cloud Connector instance. This is not recommended for production use. Defaults to false.
 - `username` (String) The username used for Basic Authentication with the Cloud Connector instance. This can also be sourced from the `SCC_USERNAME` environment variable (useful when storing and retrieving secrets from secure stores).
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -79,9 +79,9 @@ func validateAuthMode(useBasicAuth, useCertAuth bool) diag.Diagnostics {
 }
 
 func buildTLSConfig(caCert, clientCert, clientKey []byte, useCertAuth bool, skipSSLValidation bool) (*tls.Config, diag.Diagnostics) {
-	// if Certificate based authentication, it is mandatory to provide CA Certificate
+	// if Certificate based authentication without SSL skip, it is mandatory to provide CA Certificate
 	var diags diag.Diagnostics
-	if len(caCert) == 0 && useCertAuth {
+	if len(caCert) == 0 && useCertAuth && !skipSSLValidation {
 		diags.AddError("Missing CA Certificate", "When using certificate-based authentication, a CA certificate must be provided.")
 		return nil, diags
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -27,7 +27,7 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
-func NewRestApiClient(client *http.Client, baseURL *url.URL, username, password string, caCertBytes []byte, clientCertBytes []byte, clientCertKey []byte) (*RestApiClient, diag.Diagnostics) {
+func NewRestApiClient(client *http.Client, baseURL *url.URL, username, password string, caCertBytes []byte, clientCertBytes []byte, clientCertKey []byte, skipSSLValidation bool) (*RestApiClient, diag.Diagnostics) {
 	useBasicAuth, useCertAuth := isBasicAuthProvided(username, password), isCertAuthProvided(clientCertBytes, clientCertKey)
 
 	diags := validateAuthMode(useBasicAuth, useCertAuth)
@@ -35,7 +35,7 @@ func NewRestApiClient(client *http.Client, baseURL *url.URL, username, password 
 		return nil, diags
 	}
 
-	tlsConfig, diags := buildTLSConfig(caCertBytes, clientCertBytes, clientCertKey, useCertAuth)
+	tlsConfig, diags := buildTLSConfig(caCertBytes, clientCertBytes, clientCertKey, useCertAuth, skipSSLValidation)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -78,7 +78,7 @@ func validateAuthMode(useBasicAuth, useCertAuth bool) diag.Diagnostics {
 	}
 }
 
-func buildTLSConfig(caCert, clientCert, clientKey []byte, useCertAuth bool) (*tls.Config, diag.Diagnostics) {
+func buildTLSConfig(caCert, clientCert, clientKey []byte, useCertAuth bool, skipSSLValidation bool) (*tls.Config, diag.Diagnostics) {
 	// if Certificate based authentication, it is mandatory to provide CA Certificate
 	var diags diag.Diagnostics
 	if len(caCert) == 0 && useCertAuth {
@@ -86,15 +86,21 @@ func buildTLSConfig(caCert, clientCert, clientKey []byte, useCertAuth bool) (*tl
 		return nil, diags
 	}
 
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: skipSSLValidation,
+	}
 
-	if len(caCert) > 0 {
+	if !skipSSLValidation && len(caCert) > 0 {
 		caCertPool := x509.NewCertPool()
+
 		if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
-			// If the CA certificate is not valid PEM-encoded data, return an error
-			diags.AddError("Invalid CA Certificate", "The provided CA certificate is not valid PEM-encoded data.")
+			diags.AddError(
+				"Invalid CA Certificate",
+				"The provided CA certificate is not valid PEM-encoded data.",
+			)
 			return nil, diags
 		}
+
 		tlsConfig.RootCAs = caCertPool
 	}
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -112,7 +112,7 @@ func TestRestApiClient_BothAuthProvidedFails(t *testing.T) {
 	baseURL, _ := url.Parse("https://localhost")
 	certPEM, keyPEM, _, _ := generateSelfSignedCert()
 	// Provided both basic authentication(username/password) and certificate based authentication to the function
-	client, diags := NewRestApiClient(nil, baseURL, "user", "pass", certPEM, certPEM, keyPEM)
+	client, diags := NewRestApiClient(nil, baseURL, "user", "pass", certPEM, certPEM, keyPEM, false)
 
 	assert.Nil(t, client, "expected client to be nil when both auth methods are provided")
 	assert.True(t, diags.HasError(), "expected diagnostics to have error")
@@ -125,7 +125,7 @@ func TestRestApiClient_BothAuthProvidedFails(t *testing.T) {
 func TestRestApiClient_NoAuthProvidedFails(t *testing.T) {
 	baseURL, _ := url.Parse("https://localhost")
 	// Provided neither basic authentication(username/password) nor certificate based authentication to the function
-	client, diags := NewRestApiClient(nil, baseURL, "", "", nil, nil, nil)
+	client, diags := NewRestApiClient(nil, baseURL, "", "", nil, nil, nil, false)
 	assert.Nil(t, client)
 	assert.True(t, diags.HasError(), "expected error for no auth provided")
 
@@ -138,7 +138,7 @@ func TestRestApiClient_InvalidClientCertFails(t *testing.T) {
 	baseURL, _ := url.Parse("https://localhost")
 	// Generate invalid client certificate and key and provided to the function
 	invalidPEM := []byte("not a valid pem")
-	client, diags := NewRestApiClient(nil, baseURL, "", "", nil, invalidPEM, invalidPEM)
+	client, diags := NewRestApiClient(nil, baseURL, "", "", nil, invalidPEM, invalidPEM, false)
 
 	assert.Nil(t, client)
 	assert.True(t, diags.HasError(), "expected error for invalid client cert")
@@ -154,7 +154,7 @@ func TestRestApiClient_InvalidCACertFails(t *testing.T) {
 	certPEM, keyPEM, _, _ := generateSelfSignedCert()
 	// Generate invalid CA Certificate
 	invalidCA := []byte("not valid pem")
-	client, diags := NewRestApiClient(nil, baseURL, "", "", invalidCA, certPEM, keyPEM)
+	client, diags := NewRestApiClient(nil, baseURL, "", "", invalidCA, certPEM, keyPEM, false)
 
 	assert.Nil(t, client)
 	assert.True(t, diags.HasError(), "expected CA cert parse error")
@@ -286,7 +286,7 @@ func createBasicAuthClient(serverURL string) (*RestApiClient, diag.Diagnostics) 
 		return nil, diags
 	}
 
-	return NewRestApiClient(nil, baseURL, "testuser", "testpassword", nil, nil, nil)
+	return NewRestApiClient(nil, baseURL, "testuser", "testpassword", nil, nil, nil, false)
 }
 
 func createCertAuthClient(serverURL string, serverCACert, clientCert, clientKey []byte) (*RestApiClient, diag.Diagnostics) {
@@ -297,7 +297,7 @@ func createCertAuthClient(serverURL string, serverCACert, clientCert, clientKey 
 		return nil, diags
 	}
 
-	return NewRestApiClient(nil, baseURL, "", "", serverCACert, clientCert, clientKey)
+	return NewRestApiClient(nil, baseURL, "", "", serverCACert, clientCert, clientKey, false)
 }
 
 func TestRestApiClient_DoRequest_BinaryResponse(t *testing.T) {

--- a/scc/provider/provider.go
+++ b/scc/provider/provider.go
@@ -52,6 +52,7 @@ type CloudConnectorProviderData struct {
 	CaCertificate     types.String `tfsdk:"ca_certificate"`
 	ClientCertificate types.String `tfsdk:"client_certificate"`
 	ClientKey         types.String `tfsdk:"client_key"`
+	SkipSSLValidation types.Bool   `tfsdk:"skip_ssl_validation"`
 }
 
 func (c *CloudConnectorProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -107,6 +108,10 @@ Use **file(\"path/to/client_key.pem\")** in the provider block to load from a fi
 				Optional:  true,
 				Sensitive: true,
 			},
+			"skip_ssl_validation": schema.BoolAttribute{
+				MarkdownDescription: "Whether to skip SSL certificate validation when connecting to the Cloud Connector instance. This is not recommended for production use. Defaults to false.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -123,10 +128,10 @@ func (c *CloudConnectorProvider) Configure(ctx context.Context, req provider.Con
 		return
 	}
 
-	instanceURL, username, password, caCertificate, clientCertificate, clientKey := resolveAttributes(config)
+	instanceURL, username, password, caCertificate, clientCertificate, clientKey, skipSSLValidation := resolveAttributes(config)
 
 	// Validate values from config
-	if !ValidateConfig(instanceURL, username, password, caCertificate, clientCertificate, clientKey, resp) {
+	if !ValidateConfig(instanceURL, username, password, caCertificate, clientCertificate, clientKey, skipSSLValidation, resp) {
 		return
 	}
 
@@ -136,7 +141,7 @@ func (c *CloudConnectorProvider) Configure(ctx context.Context, req provider.Con
 		return
 	}
 	// Create Client
-	client := CreateClient(c.HttpClient, parsedURL, username, password, caCertificate, clientCertificate, clientKey, resp)
+	client := CreateClient(c.HttpClient, parsedURL, username, password, caCertificate, clientCertificate, clientKey, skipSSLValidation, resp)
 	if client == nil {
 		return
 	}
@@ -152,13 +157,21 @@ func (c *CloudConnectorProvider) Configure(ctx context.Context, req provider.Con
 	resp.ActionData = client
 }
 
-func resolveAttributes(config CloudConnectorProviderData) (string, string, string, string, string, string) {
+func resolveAttributes(config CloudConnectorProviderData) (string, string, string, string, string, string, bool) {
 	return getNonEmptyAttribute(config.InstanceURL, "SCC_INSTANCE_URL"),
 		getNonEmptyAttribute(config.Username, "SCC_USERNAME"),
 		getNonEmptyAttribute(config.Password, "SCC_PASSWORD"),
 		getNonEmptyAttribute(config.CaCertificate, "SCC_CA_CERTIFICATE"),
 		getNonEmptyAttribute(config.ClientCertificate, "SCC_CLIENT_CERTIFICATE"),
-		getNonEmptyAttribute(config.ClientKey, "SCC_CLIENT_KEY")
+		getNonEmptyAttribute(config.ClientKey, "SCC_CLIENT_KEY"),
+		getBoolAttribute(config.SkipSSLValidation, "SCC_SKIP_SSL_VALIDATION")
+}
+
+func getBoolAttribute(attr types.Bool, envVar string) bool {
+	if !attr.IsNull() {
+		return attr.ValueBool()
+	}
+	return os.Getenv(envVar) == "true"
 }
 
 func getNonEmptyAttribute(attr types.String, envVar string) string {
@@ -168,7 +181,7 @@ func getNonEmptyAttribute(attr types.String, envVar string) string {
 	return os.Getenv(envVar)
 }
 
-func ValidateConfig(instanceURL, username, password, caCertificate, clientCertificate, clientKey string, resp *provider.ConfigureResponse) bool {
+func ValidateConfig(instanceURL, username, password, caCertificate, clientCertificate, clientKey string, skipSSLValidation bool, resp *provider.ConfigureResponse) bool {
 	if instanceURL == "" {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("instance_url"),
@@ -186,6 +199,13 @@ func ValidateConfig(instanceURL, username, password, caCertificate, clientCertif
 	}
 	if clientKey != "" && !ValidatePEMBlock(clientKey, "client_key", "Client Key", resp) {
 		return false
+	}
+
+	if skipSSLValidation && caCertificate != "" {
+		resp.Diagnostics.AddWarning(
+			"CA Certificate Ignored",
+			"The ca_certificate attribute is ignored when skip_ssl_validation is set to true.",
+		)
 	}
 
 	basicAuth := username != "" && password != ""
@@ -220,7 +240,7 @@ func ParseInstanceURL(instanceURL string, resp *provider.ConfigureResponse) *url
 	}
 	return parsedURL
 }
-func CreateClient(httpClient *http.Client, parsedURL *url.URL, username, password, caCertificate, clientCertificate, clientKey string, resp *provider.ConfigureResponse) *api.RestApiClient {
+func CreateClient(httpClient *http.Client, parsedURL *url.URL, username, password, caCertificate, clientCertificate, clientKey string, skipSSLValidation bool, resp *provider.ConfigureResponse) *api.RestApiClient {
 	client, diags := api.NewRestApiClient(
 		httpClient,
 		parsedURL,
@@ -229,6 +249,7 @@ func CreateClient(httpClient *http.Client, parsedURL *url.URL, username, passwor
 		[]byte(caCertificate),
 		[]byte(clientCertificate),
 		[]byte(clientKey),
+		skipSSLValidation,
 	)
 	if diags.HasError() {
 		resp.Diagnostics.AddError(

--- a/scc/provider/provider.go
+++ b/scc/provider/provider.go
@@ -109,7 +109,7 @@ Use **file(\"path/to/client_key.pem\")** in the provider block to load from a fi
 				Sensitive: true,
 			},
 			"skip_ssl_validation": schema.BoolAttribute{
-				MarkdownDescription: "Whether to skip SSL certificate validation when connecting to the Cloud Connector instance. This is not recommended for production use. Defaults to false.",
+				MarkdownDescription: "Whether to skip SSL certificate validation when connecting to the Cloud Connector instance. This can also be sourced from the `SCC_SKIP_SSL_VALIDATION` environment variable. This is not recommended for production use. Defaults to false.",
 				Optional:            true,
 			},
 		},

--- a/scc/provider/provider_test.go
+++ b/scc/provider/provider_test.go
@@ -161,7 +161,7 @@ func TestSCCProvider_AllActions(t *testing.T) {
 
 func TestSCCProvider_MissingURL(t *testing.T) {
 	var resp tfprovider.ConfigureResponse
-	ok := provider.ValidateConfig("", "admin", "pass", "", "", "", &resp)
+	ok := provider.ValidateConfig("", "admin", "pass", "", "", "", false, &resp)
 
 	assert.False(t, ok)
 	assert.True(t, resp.Diagnostics.HasError())
@@ -173,7 +173,7 @@ func TestSCCProvider_ErrorParseURL(t *testing.T) {
 	// Build invalid URL using non-constant expression to bypass staticcheck
 	invalidURL := fmt.Sprintf("ht%ctp://bad-url", '!')
 
-	ok := provider.ValidateConfig(invalidURL, "admin", "pass", "", "", "", &resp)
+	ok := provider.ValidateConfig(invalidURL, "admin", "pass", "", "", "", false, &resp)
 
 	_, err := url.Parse(invalidURL)
 	if err != nil {
@@ -191,7 +191,7 @@ func TestSCCProvider_ErrorParseURL(t *testing.T) {
 
 func TestSCCProvider_BasicAuthOnly(t *testing.T) {
 	var resp tfprovider.ConfigureResponse
-	ok := provider.ValidateConfig("https://example.com", "admin", "pass", "", "", "", &resp)
+	ok := provider.ValidateConfig("https://example.com", "admin", "pass", "", "", "", false, &resp)
 
 	assert.True(t, ok)
 	assert.False(t, resp.Diagnostics.HasError())
@@ -199,7 +199,7 @@ func TestSCCProvider_BasicAuthOnly(t *testing.T) {
 
 func TestSCCProvider_ConflictingAuth(t *testing.T) {
 	var resp tfprovider.ConfigureResponse
-	ok := provider.ValidateConfig("https://example.com", "admin", "pass", "", "cert", "key", &resp)
+	ok := provider.ValidateConfig("https://example.com", "admin", "pass", "", "cert", "key", false, &resp)
 
 	assert.False(t, ok)
 	assert.True(t, resp.Diagnostics.HasError())
@@ -218,7 +218,7 @@ IwQYMBaAFENZqO6v+u1eZzZTVDNj0uUCkN8gMAwGA1UdEwQFMAMBAf8wCgYIKoZI
 zj0EAwIDSAAwRQIgTTb7LtqRQon2OHxMOyuvl+e8FQZXzSH14Yc7u9s9n9ICIQDE
 CEGH5OML6z7C7oCSys7ce4GkTbtJ4rNZoxVOxFwPvA==
 -----END CERTIFICATE-----`
-	ok := provider.ValidateConfig("https://example.com", "", "", dummyPEM, dummyPEM, dummyPEM, &resp)
+	ok := provider.ValidateConfig("https://example.com", "", "", dummyPEM, dummyPEM, dummyPEM, false, &resp)
 
 	assert.True(t, ok)
 	assert.False(t, resp.Diagnostics.HasError())
@@ -227,7 +227,7 @@ CEGH5OML6z7C7oCSys7ce4GkTbtJ4rNZoxVOxFwPvA==
 // Test that empty auth results in error.
 func TestSCCProvider_NoAuth(t *testing.T) {
 	var resp tfprovider.ConfigureResponse
-	ok := provider.ValidateConfig("https://example.com", "", "", "", "", "", &resp)
+	ok := provider.ValidateConfig("https://example.com", "", "", "", "", "", false, &resp)
 
 	assert.False(t, ok)
 	assert.True(t, resp.Diagnostics.HasError())
@@ -274,7 +274,7 @@ CEGH5OML6z7C7oCSys7ce4GkTbtJ4rNZoxVOxFwPvA==
 	username := "admin"
 	password := "password"
 
-	ok := provider.ValidateConfig(instanceURL, username, password, dummyPEM, dummyPEM, dummyPEM, &resp)
+	ok := provider.ValidateConfig(instanceURL, username, password, dummyPEM, dummyPEM, dummyPEM, false, &resp)
 
 	assert.False(t, ok)
 	assert.True(t, resp.Diagnostics.HasError())
@@ -373,7 +373,7 @@ func TestSCCProvider_CreateClient_Success(t *testing.T) {
 	httpClient := &http.Client{}
 	parsedURL := mustParseURL(t, "https://example.com")
 
-	client := provider.CreateClient(httpClient, parsedURL, "user", "pass", "", "", "", &resp)
+	client := provider.CreateClient(httpClient, parsedURL, "user", "pass", "", "", "", false, &resp)
 
 	assert.NotNil(t, client)
 	assert.False(t, resp.Diagnostics.HasError())
@@ -386,7 +386,7 @@ func TestSCCProvider_CreateClient_Failure_InvalidCert(t *testing.T) {
 
 	invalidCert := "-----BEGIN BAD-----"
 
-	client := provider.CreateClient(httpClient, parsedURL, "", "", invalidCert, invalidCert, invalidCert, &resp)
+	client := provider.CreateClient(httpClient, parsedURL, "", "", invalidCert, invalidCert, invalidCert, false, &resp)
 
 	assert.Nil(t, client)
 	assert.True(t, resp.Diagnostics.HasError())


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Closes: https://github.com/SAP/terraform-provider-scc/issues/351
- Added support for the optional provider attribute skip_ssl_validation.
- Allows users to connect to SAP Cloud Connector instances that use self-signed or internally issued certificates without requiring the certificate to be imported into the system trust store.
- Additionally, the existing certificate validation mechanism using a trusted CA certificate remains fully supported. Users can continue to provide and trust CA certificates for secure TLS communication without disabling certificate verification.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
