### PR TITLE
feat: Enhanced Subaccount Datasource

### DIFF
--- a/docs/data-sources/subaccount_configuration.md
+++ b/docs/data-sources/subaccount_configuration.md
@@ -43,8 +43,10 @@ data "scc_subaccount_configuration" "by_id" {
 
 ### Read-Only
 
+- `auto_certificate_renewal` (Boolean) Indicates whether auto-renewal of the subaccount certificate is enabled (as of version 2.19).
 - `description` (String) Description of the subaccount.
 - `display_name` (String) Display name of the subaccount.
+- `is_managed` (Boolean) Indicates whether the subaccount is a managed subaccount (as of version 2.19).
 - `location_id` (String) Location identifier for the Cloud Connector instance. This property is not available if the default location ID is in use.
 - `tunnel` (Attributes) Array of connection tunnels used by the subaccount. (see [below for nested schema](#nestedatt--tunnel))
 

--- a/internal/api/apiObjects/types_subaccount.go
+++ b/internal/api/apiObjects/types_subaccount.go
@@ -1,12 +1,14 @@
 package apiobjects
 
 type Subaccount struct {
-	RegionHost  string           `json:"regionHost"`
-	Subaccount  string           `json:"subaccount"`
-	LocationID  string           `json:"locationID"`
-	DisplayName string           `json:"displayName"`
-	Description string           `json:"description"`
-	Tunnel      SubaccountTunnel `json:"tunnel"`
+	RegionHost             string           `json:"regionHost"`
+	Subaccount             string           `json:"subaccount"`
+	LocationID             string           `json:"locationID"`
+	DisplayName            string           `json:"displayName"`
+	Description            string           `json:"description"`
+	AutoCertificateRenewal *bool            `json:"autoCertRenewal,omitempty"`
+	IsManaged              *bool            `json:"isManaged,omitempty"`
+	Tunnel                 SubaccountTunnel `json:"tunnel"`
 }
 
 type Subaccounts struct {

--- a/scc/provider/datasources/datasource_subaccount_configuration.go
+++ b/scc/provider/datasources/datasource_subaccount_configuration.go
@@ -66,6 +66,14 @@ __Further documentation:__
 				MarkdownDescription: "Description of the subaccount.",
 				Computed:            true,
 			},
+			"auto_certificate_renewal": schema.BoolAttribute{
+				MarkdownDescription: "Indicates whether auto-renewal of the subaccount certificate is enabled (as of version 2.19).",
+				Computed:            true,
+			},
+			"is_managed": schema.BoolAttribute{
+				MarkdownDescription: "Indicates whether the subaccount is a managed subaccount (as of version 2.19).",
+				Computed:            true,
+			},
 			"tunnel": schema.SingleNestedAttribute{
 				MarkdownDescription: "Array of connection tunnels used by the subaccount.",
 				Computed:            true,

--- a/scc/provider/model/type_subaccount.go
+++ b/scc/provider/model/type_subaccount.go
@@ -11,12 +11,14 @@ import (
 )
 
 type SubaccountData struct {
-	RegionHost  types.String `tfsdk:"region_host"`
-	Subaccount  types.String `tfsdk:"subaccount"`
-	LocationID  types.String `tfsdk:"location_id"`
-	DisplayName types.String `tfsdk:"display_name"`
-	Description types.String `tfsdk:"description"`
-	Tunnel      types.Object `tfsdk:"tunnel"`
+	RegionHost             types.String `tfsdk:"region_host"`
+	Subaccount             types.String `tfsdk:"subaccount"`
+	LocationID             types.String `tfsdk:"location_id"`
+	DisplayName            types.String `tfsdk:"display_name"`
+	Description            types.String `tfsdk:"description"`
+	Tunnel                 types.Object `tfsdk:"tunnel"`
+	AutoCertificateRenewal types.Bool   `tfsdk:"auto_certificate_renewal"`
+	IsManaged              types.Bool   `tfsdk:"is_managed"`
 }
 
 type SubaccountTunnelData struct {
@@ -207,13 +209,25 @@ func SubaccountDataSourceValueFrom(ctx context.Context, value apiobjects.Subacco
 		return SubaccountData{}, diags
 	}
 
+	autoCertRenewal := types.BoolNull()
+	if value.AutoCertificateRenewal != nil {
+		autoCertRenewal = types.BoolValue(*value.AutoCertificateRenewal)
+	}
+
+	isManaged := types.BoolNull()
+	if value.IsManaged != nil {
+		isManaged = types.BoolValue(*value.IsManaged)
+	}
+
 	model := &SubaccountData{
-		RegionHost:  types.StringValue(value.RegionHost),
-		Subaccount:  types.StringValue(value.Subaccount),
-		LocationID:  types.StringValue(value.LocationID),
-		DisplayName: types.StringValue(value.DisplayName),
-		Description: types.StringValue(value.Description),
-		Tunnel:      tunnel,
+		RegionHost:             types.StringValue(value.RegionHost),
+		Subaccount:             types.StringValue(value.Subaccount),
+		LocationID:             types.StringValue(value.LocationID),
+		DisplayName:            types.StringValue(value.DisplayName),
+		Description:            types.StringValue(value.Description),
+		AutoCertificateRenewal: autoCertRenewal,
+		IsManaged:              isManaged,
+		Tunnel:                 tunnel,
 	}
 	return *model, diag.Diagnostics{}
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Closes: https://github.com/SAP/terraform-provider-scc/issues/353
- Extended the scc_subaccount_configuration data source to expose additional subaccount attributes introduced in SAP Cloud Connector 2.19:
1. auto_certificate_renewal
2. is_managed

- Updated the datasource schema and model mapping to retrieve and expose these properties from the Cloud Connector REST API.
- Maintained backward compatibility with earlier Cloud Connector versions where these attributes are not available.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
