### PR TITLE
chore: remove go report card as retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![Golang](https://img.shields.io/badge/Go-1.26-informational)
-[![Go Report Card](https://goreportcard.com/badge/github.com/SAP/terraform-provider-scc)](https://goreportcard.com/report/github.com/SAP/terraform-provider-scc)
 [![CodeQL](https://github.com/SAP/terraform-provider-scc/actions/workflows/codeql.yml/badge.svg)](https://github.com/SAP/terraform-provider-scc/actions/workflows/codeql.yml)
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/terraform-provider-scc)](https://api.reuse.software/info/github.com/SAP/terraform-provider-scc)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10659/badge)](https://www.bestpractices.dev/projects/10659)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Remove Go Report Card from `README.md` as the underlying project is retired (see https://goreportcard.com/report/github.com/SAP/terraform-provider-scc)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[] Documentation content changes
[X] Other... Please describe: Chnage of badges
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
